### PR TITLE
Use File.expand_path in script/server.

### DIFF
--- a/script/server
+++ b/script/server
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
-require File.dirname(__FILE__) + '/../config/boot'
+require File.expand_path('../../config/boot', __FILE__)
 require 'commands/server'


### PR DESCRIPTION
Be compatible with Ruby 1.9 and later.

Before fix: 

```
$ ruby -v
ruby 1.9.3p392 (2013-02-22 revision 39386) [x86_64-darwin11.4.2]
$ bundle exec script/server
script/server:2:in `require': cannot load such file -- script/../config/boot (LoadError)
    from script/server:2:in `<main>'
```
