### PR TITLE
Add verification gem (forked) to enable boot on RAILS_ENV=production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'haml'
 gem 'feed-normalizer'
 gem 'rfeedfinder'
 gem 'opml'
+gem 'verification', github: 'sikachu/verification'
 
 
 # Gems used only for assets and not required

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: git://github.com/sikachu/verification.git
+  revision: 7c692e3cdb7e3c9dd075503baeb63a1022025f08
+  specs:
+    verification (1.0.3)
+      actionpack (>= 3.0.0, < 3.3.0)
+      activesupport (>= 3.0.0, < 3.3.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -125,3 +133,4 @@ DEPENDENCIES
   sass-rails (~> 3.2.3)
   sqlite3
   uglifier (>= 1.0.3)
+  verification!


### PR DESCRIPTION
At production environment rails raises `undefined method 'verify'` error and cannot boot because `verify` method is no longer available on rails 3.

---

`$ RAILS_ENV=production bundle exec rails server` すると `undefined method 'verify'` という例外が発生して起動しません。
これは AccountsController などで使われている `verify` が Rails 2.3.8 以降廃止された (らしい) からなので、外部プラグイン化されたものを追加利用して例外回避しました (rubygems.org の verification は古くて Rails 3.2.x では動かないので fork のほうを入れました)

`verify` をやめて `before_filter` に置き換えたほうが良いとは思います (応急処置のつもりです)

あとなぜ `development` では例外が発生しないのかは不明です。
