### PR TITLE
Pass absolute (expanded) path to require

### DIFF
--- a/script/crawler
+++ b/script/crawler
@@ -12,7 +12,7 @@ ARGV.options do |opt|
   opt.parse!
 end
 
-require File.dirname(__FILE__) + '/../config/environment'
+require File.expand_path(File.dirname(__FILE__) + '/../config/environment')
 require "fastladder/crawler"
 
 if options[:daemon]


### PR DESCRIPTION
Since the ruby's load path policy was changed from 1.9 or higher.

---

Ruby 1.9 以降は `require 'script/../config/environment'` のような相対パス指定はできなくなったので、絶対パスに展開して渡すように修正しました。
