### PR TITLE
Fix mass-assignment error on crawling/reading feeds

### DIFF
--- a/app/models/crawl_status.rb
+++ b/app/models/crawl_status.rb
@@ -1,5 +1,6 @@
 class CrawlStatus < ActiveRecord::Base
   belongs_to :feed
+  attr_accessible :status, :crawled_on
 
   def self.fetch_crawlable_feed(options = {})
     CrawlStatus.update_all("status = #{Fastladder::Crawler::CRAWL_OK}", ['crawled_on < ?', 24.hours.ago])

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,5 +1,5 @@
 class Subscription < ActiveRecord::Base
-  attr_accessible :feed_id, :has_unread, :folder_id, :rate, :public
+  attr_accessible :feed_id, :has_unread, :folder_id, :rate, :public, :viewed_on
   belongs_to :member
   belongs_to :feed
   belongs_to :folder


### PR DESCRIPTION
To supress mass-assignment error, I add some fields to `attr_accessible`. 
These field are used on crawling and reading feeds.
