### PR TITLE
Fix NameError on API Controller

### DIFF
--- a/app/controllers/api/feed_controller.rb
+++ b/app/controllers/api/feed_controller.rb
@@ -20,7 +20,7 @@ class Api::FeedController < ApplicationController
           :link => feed.link,
           :title => feed.title,
         }
-        if sub = member.subscriptions.find_by_feed_id(feed.id)
+        if sub = @member.subscriptions.find_by_feed_id(feed.id)
           result[:subscribe_id] = sub.id
         end
         feeds << result
@@ -82,12 +82,12 @@ class Api::FeedController < ApplicationController
     sub_id = (params[:subscribe_id] || 0).to_i
     sub = nil
     if sub_id > 0
-      sub = member.subscriptions.find_by_id(sub_id)
+      sub = @member.subscriptions.find_by_id(sub_id)
     else
       if feedlink.blank? or (feed = Feed.find_by_feedlink(feedlink)).nil?
         return render_json_status(false)
       end
-      sub = member.subscriptions.find_by_feed_id(feed.id)
+      sub = @member.subscriptions.find_by_feed_id(feed.id)
     end
     unless sub
       return render_json_status(false)
@@ -117,7 +117,7 @@ class Api::FeedController < ApplicationController
       sub.public = params[:public].to_i == 1
       updated = true
     end
-    if (folder_id = params[:folder_id].to_i) > 0 and member.folders.exists?(folder_id)
+    if (folder_id = params[:folder_id].to_i) > 0 and @member.folders.exists?(folder_id)
       sub.folder_id = folder_id
       updated = true
     end
@@ -136,15 +136,15 @@ class Api::FeedController < ApplicationController
     if dest.blank?
       folder_id = nil
     else
-      unless folder = member.folders.find_by_name(dest)
-        unless folder = member.folders.find_by_id(dest.to_i)
+      unless folder = @member.folders.find_by_name(dest)
+        unless folder = @member.folders.find_by_id(dest.to_i)
           return render_json_status(false)
         end
       end
       folder_id = folder.id
     end
     (params[:subscribe_id] || "").split(/\s*,\s*/).each do |id|
-      if sub = member.subscriptions.find_by_id(id)
+      if sub = @member.subscriptions.find_by_id(id)
         sub.update_attribute(:folder_id, folder_id)
       end
     end
@@ -167,7 +167,7 @@ class Api::FeedController < ApplicationController
     end
     ignore = ignore.to_i != 0
     sub_id.split(/\s*,\s*/).each do |id|
-      if sub = member.subscriptions.find_by_id(id.to_i)
+      if sub = @member.subscriptions.find_by_id(id.to_i)
         sub.update_attribute(:ignore_notify, ignore)
       end
     end
@@ -180,7 +180,7 @@ class Api::FeedController < ApplicationController
     end
     is_public = is_public.to_i != 0
     sub_id.split(/\s*,\s*/).each do |id|
-      if sub = member.subscriptions.find_by_id(id.to_i)
+      if sub = @member.subscriptions.find_by_id(id.to_i)
         sub.update_attribute(:public, is_public)
       end
     end
@@ -202,6 +202,6 @@ protected
     if params[:subscribe_id].blank? or (sub_id = params[:subscribe_id].to_i) <= 0
       return nil
     end
-    member.subscriptions.find_by_id(sub_id)
+    @member.subscriptions.find_by_id(sub_id)
   end
 end

--- a/app/controllers/api/folder_controller.rb
+++ b/app/controllers/api/folder_controller.rb
@@ -13,10 +13,10 @@ class Api::FolderController < ApplicationController
       return render_json_status(false)
     end
     Folder.transaction do
-      if member.folders.find_by_name(name)
+      if @member.folders.find_by_name(name)
         return render_json_status(false, ERR_ALREADY_EXISTS)
       end
-      member.folders.create(:name => name)
+      @member.folders.create(:name => name)
     end
     render_json_status(true)
   end
@@ -44,7 +44,7 @@ class Api::FolderController < ApplicationController
 protected
   def get_folder
     if (folder_id = params[:folder_id].to_i) > 0
-      return member.folders.find_by_id(folder_id)
+      return @member.folders.find_by_id(folder_id)
     end
     return nil
   end

--- a/app/controllers/api/pin_controller.rb
+++ b/app/controllers/api/pin_controller.rb
@@ -12,9 +12,9 @@ class Api::PinController < ApplicationController
   def add
     link = params[:link]
     title = params[:title]
-    member.pins.create(:link => link, :title => title)
-    if (diff = member.pins.size - SAVE_PIN_LIMIT) > 0
-      member.pins.find(:all, :order => "created_on", :limit => diff).each do |pin|
+    @member.pins.create(:link => link, :title => title)
+    if (diff = @member.pins.size - SAVE_PIN_LIMIT) > 0
+      @member.pins.find(:all, :order => "created_on", :limit => diff).each do |pin|
         pin.destroy
       end
     end
@@ -22,7 +22,7 @@ class Api::PinController < ApplicationController
   end
 
   def remove
-    unless pin = member.pins.find_by_link(params[:link])
+    unless pin = @member.pins.find_by_link(params[:link])
       return render_json_status(false, 2)
     end
     pin.destroy
@@ -30,7 +30,7 @@ class Api::PinController < ApplicationController
   end
 
   def clear
-    Pin.delete_all(:member_id => member.id)
+    Pin.delete_all(:member_id => @member.id)
     render_json_status(true)
   end
 end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -46,7 +46,7 @@ class ApiController < ApplicationController
 
   def touch_all
     params[:subscribe_id].split(/\s*,\s*/).each do |id|
-      if sub = member.subscriptions.find_by_id(id)
+      if sub = @member.subscriptions.find_by_id(id)
         sub.update_attributes(:has_unread => false, :viewed_on => DateTime.now)
       end
     end
@@ -56,7 +56,7 @@ class ApiController < ApplicationController
   def touch
     timestamps = params[:timestamp].split(/\s*, \s*/).map { |t| t.to_i }
     params[:subscribe_id].split(/\s*,\s*/).each_with_index do |id, i|
-      if sub = Subscription.find(id) and sub.member_id == member.id and timestamps[i]
+      if sub = Subscription.find(id) and sub.member_id == @member.id and timestamps[i]
         sub.update_attributes(:has_unread => false, :viewed_on => Time.new(timestamps[i] + 1))
       end
     end
@@ -153,7 +153,7 @@ class ApiController < ApplicationController
   def crawl
     success = false
     params[:subscribe_id].to_s.split(/\s*,\s*/).each_with_index do |id, i|
-      if sub = Subscription.find(id) and sub.member_id == member.id
+      if sub = Subscription.find(id) and sub.member_id == @member.id
         success = sub.feed.crawl
       end
     end


### PR DESCRIPTION
Because `before_filter :login` introduces `@member` instead of `member`, we should use it.
