### PR TITLE
Add simplecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ config/database.yml
 db/schema.rb
 lib/*.dylib
 db/*.sqlite3
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ group :development, :test do
   gem 'capybara'
   gem 'launchy'
   gem 'factory_girl_rails'
+  gem 'simplecov'
+  gem 'simplecov-rcov'
 end
 
 # To use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,12 @@ GEM
       rubyzip
       websocket (~> 1.0.4)
     simple-rss (1.2.3)
+    simplecov (0.7.1)
+      multi_json (~> 1.0)
+      simplecov-html (~> 0.7.1)
+    simplecov-html (0.7.1)
+    simplecov-rcov (0.2.3)
+      simplecov (>= 0.4.1)
     slop (3.4.4)
     sprockets (2.2.2)
       hike (~> 1.2)
@@ -195,6 +201,8 @@ DEPENDENCIES
   rfeedfinder
   rspec-rails
   sass-rails (~> 3.2.3)
+  simplecov
+  simplecov-rcov
   sqlite3
   uglifier (>= 1.0.3)
   verification!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,16 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
+
+if ENV["COV"]
+  require 'simplecov'
+  require 'simplecov-rcov'
+  SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
+  SimpleCov.start 'rails'
+else
+  STDERR.puts('Run with `COV=1` if you want to generate simplecov coverage reports.')
+end
+
 ENV["RAILS_ENV"] ||= 'test'
+
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'rspec/autorun'
@@ -20,7 +31,7 @@ RSpec.configure do |config|
   # config.mock_with :rr
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.fixture_path = ::Rails.root.join('spec/fixtures')
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
I added simplecov and simplecov-cov to the project.
When running spec with `COV=1` env variable, simplecov coverage reports are generate to `/coverage`

``` sh
$ COV=1 rake spec
```

simplecov(-rcov) を導入しました。
