### PR TITLE
fix API routing

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,9 +24,9 @@ Fastladder::Application.routes.draw do
   match 'reader' => 'reader#index'
   match 'contents/guide' => 'contents#guide'
   match 'contents/config' => 'contents#configure'
-  match 'api/pin/all' => 'api/pin#all'
-  match 'api/feed/discover' => 'api/feed#discover'
-  match 'api/feed/subscribe' => 'api/feed#subscribe'
+  match 'api/pin/:action' => 'api/pin'
+  match 'api/feed/:action' => 'api/feed'
+  match 'api/folder/:action' => 'api/folder'
 
   match 'import' => 'import#index'
 

--- a/spec/routing/api/config_routing_spec.rb
+++ b/spec/routing/api/config_routing_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'routing to api/config' do
+  it 'routes load' do
+    expect(get('/api/config/load')).to route_to('api/config#getter')
+  end
+
+  it 'routes save' do
+    expect(post('/api/config/save')).to route_to('api/config#setter')
+  end
+end

--- a/spec/routing/api/feed_routing_spec.rb
+++ b/spec/routing/api/feed_routing_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'routing to api/feed' do
+  %w(discover subscribed).each do|name|
+    it "routes #{name}" do
+      expect(get("/api/feed/#{name}")).to route_to("api/feed\##{name}")
+    end
+  end
+
+  %w(subscribe unsubscribe update move set_rate set_notify set_public add_tags remove_tags).each do|name|
+    it "routes #{name}" do
+      expect(post("/api/feed/#{name}")).to route_to("api/feed\##{name}")
+    end
+  end
+end

--- a/spec/routing/api/folder_routing_spec.rb
+++ b/spec/routing/api/folder_routing_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe 'routing to api/folder' do
+  %w(create update delete).each do|name|
+    it "routes #{name}" do
+      expect(post("/api/folder/#{name}")).to route_to("api/folder\##{name}")
+    end
+  end
+end

--- a/spec/routing/api/item_routing_spec.rb
+++ b/spec/routing/api/item_routing_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe 'routing to api/pin' do
+  %w(all add remove clear).each do|name|
+    it "routes #{name}" do
+      expect(post("/api/pin/#{name}")).to route_to("api/pin\##{name}")
+    end
+  end
+end

--- a/spec/routing/api/pin_routing_spec.rb
+++ b/spec/routing/api/pin_routing_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe 'routing to api/pin' do
+  %w(all add remove clear).each do|name|
+    it "routes #{name}" do
+      expect(post("/api/pin/#{name}")).to route_to("api/pin\##{name}")
+    end
+  end
+end

--- a/spec/routing/api_routing_spec.rb
+++ b/spec/routing/api_routing_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'routing to api' do
+  %w(all unread touch_all touch item_count unread_count folders crawl).each do|name|
+    it "routes #{name}" do
+      expect(get("/api/#{name}")).to route_to("api\##{name}")
+    end
+  end
+
+  %w(subs lite_subs error_subs folders).each do|name|
+    it "routes #{name}" do
+      expect(post("/api/#{name}")).to route_to("api\##{name}")
+    end
+  end
+end


### PR DESCRIPTION
Fix API routing and add routing spec.

But I don't touch about https://github.com/fastladder/fastladder/blob/rails-modern/app/controllers/api/item_controller.rb ?  What is this? Who uses this?
