### PR TITLE
Override I18n.missingTranslation

### DIFF
--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -2,6 +2,9 @@
 //= require i18n/translations
 I18n.locale = (typeof Language !== 'undefined' && Language === 'English') ? 'en' : 'ja';
 I18n.defaultSeparator = '/';
+I18n.missingTranslation = function(scope) {
+	return scope;
+};
 
 /*
  良く使う関数


### PR DESCRIPTION
733d84620a5075c082d79c6c03aff45454e67d09 よりも前で使われていた `tl()` や `getText()` は表示出来る物がなかった場合には引数をそのまま表示するようになっており、また従前のコードではそれを前提としていた箇所が複数あった為に、おかしな表示になってしまうようになっていました。

`I18n.missingTranslation` を上書きして、同様の動作をさせるようにして対処しています。
