### PR TITLE
Fix raw image tag

### DIFF
--- a/app/helpers/about_helper.rb
+++ b/app/helpers/about_helper.rb
@@ -2,7 +2,8 @@ module AboutHelper
   def users(num)
     pluralize(num, 'user')
   end
+
   def rate_image(num)
-    %Q{<img src="/img/rate/#{num}.gif" />}
+    image_tag "/img/rate/#{num}.gif", :alt => num
   end
 end


### PR DESCRIPTION
`/about/*url` に表示されているレート画像が次に示す画像のようにエスケープされてしまっていたのを修正しました。

![Screen Shot 2013-03-16 at 11 24 41 PM](https://f.cloud.github.com/assets/12539/266921/48539fe4-8e45-11e2-8640-0b73f59fb160.png)
