### PR TITLE
Fix not works on production environment

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Fastladder::Application.configure do
   # config.action_controller.asset_host = "http://assets.example.com"
 
   # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
-  config.assets.precompile += %w( application.js compat.js common.js event.js template.js api.js reader_subscribe.js round_corner.js reader_proto.js reader_pref.js reader_share.js )
+  config.assets.precompile += %w( compat.js common.js event.js template.js api.js reader_subscribe.js round_corner.js reader_proto.js reader_pref.js reader_share.js )
 
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
Assets Pipeline を導入した影響で、production 環境で動かした時に以下のようなエラーが出るのを修正します。

```
Processing by MembersController#new as HTML
  Rendered members/new.html.haml within layouts/application (11.1ms)
Completed 500 Internal Server Error in 43ms

ActionView::Template::Error (compat.js isn't precompiled):
    8: </head>
    9: <body class="<%= params[:controller] %>">
    10: <script type="text/javascript">var ApiKey = "<%= request.session_options[:id] %>";</script>
    11: <%=raw loadJS("compat","common","event","template","api","reader_subscribe","round_corner") %>
    12: <div id="container">
    13: <div class="navi">
    14: <h1 class="logo"><a href="/">Fastladder</a></h1>
  app/helpers/application_helper.rb:5:in `block in loadJS'
  app/helpers/application_helper.rb:4:in `map'
  app/helpers/application_helper.rb:4:in `loadJS'
  app/views/layouts/application.html.erb:11:in `_app_views_layouts_application_html_erb___3178349357399130755_2190074220'
```

loadJS が、生の JS を探しに行くのが原因なので、loadJS が読み込む JS をすべてプリコンパイルしておくようにしましたが、読み込む JS が増える度に production.rb も変更しなければならないので、loadJS を使わなくする方向にした方が良いかもしれません。
