### PR TITLE
fix about#index and subscribe#confirm not using format

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,10 +3,10 @@ Fastladder::Application.routes.draw do
   match 'api/config/save' => 'api/config#setter'
 
   match 'api/:action' => 'api'
-  match 'subscribe/*url' => 'subscribe#confirm', as: :subscribe
+  match 'subscribe/*url' => 'subscribe#confirm', as: :subscribe, format: false
   match 'import/finish' => 'import#finish'
   match 'import/:url' => 'import#fetch'
-  match 'about/*url' => 'about#index', as: :about
+  match 'about/*url' => 'about#index', as: :about, format: false
   match 'user/:login_name/:action' => 'user'
   match 'user/:login_name' => 'user#index'
   match 'icon/:feed' => 'icon#get'

--- a/spec/routing/about_routing_spec.rb
+++ b/spec/routing/about_routing_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe 'routing to about' do
+  it 'routes about#index' do
+    expect(get('/about/http://example.com/index.xml')).
+      to route_to(controller: "about", action: "index", url: "http://example.com/index.xml")
+  end
+end
+

--- a/spec/routing/subscribe_routing_spec.rb
+++ b/spec/routing/subscribe_routing_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe 'routing to subscribe' do
+  it 'routes subscribe#confirm' do
+    expect(get('/subscribe/http://example.com/index.xml')).
+      to route_to(controller: "subscribe", action: "confirm", url: "http://example.com/index.xml")
+  end
+end
+


### PR DESCRIPTION
access like /about/http://example.com/index.xml
raise ActionView::MissingTemplate cause by "format: :xml"
