### PR TITLE
Replace Rfeedfinder with FeedSearcher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,10 @@ gem 'mysql2'
 gem 'haml'
 # current release version has no `feed.description` method. this is why :git used
 gem 'feedzirra', :git => "https://github.com/pauldix/feedzirra"
-gem 'rfeedfinder'
 gem 'opml', github: 'kyanny/opml'
 gem 'verification', github: 'sikachu/verification'
+gem 'hpricot'
+gem 'feed_searcher'
 
 # Gems used only for assets and not required
 # in production environments by default.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,8 @@ GEM
     coffee-script-source (1.6.1)
     curb (0.8.3)
     diff-lcs (1.1.3)
+    domain_name (0.5.8)
+      unf (~> 0.0.3)
     erubis (2.7.0)
     execjs (1.4.0)
       multi_json (~> 1.0)
@@ -85,14 +87,14 @@ GEM
     factory_girl_rails (1.7.0)
       factory_girl (~> 2.6.0)
       railties (>= 3.0.0)
+    feed_searcher (0.0.2)
+      mechanize (>= 1.0.0)
+      nokogiri
     ffi (1.4.0)
     haml (4.0.0)
       tilt
     hike (1.2.1)
-    hoe (3.5.1)
-      rake (>= 0.8, < 11.0)
     hpricot (0.8.6)
-    htmlentities (4.3.1)
     i18n (0.6.4)
     i18n-js (2.1.2)
       i18n
@@ -106,11 +108,22 @@ GEM
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
+    mechanize (2.5.1)
+      domain_name (~> 0.5, >= 0.5.1)
+      mime-types (~> 1.17, >= 1.17.2)
+      net-http-digest_auth (~> 1.1, >= 1.1.1)
+      net-http-persistent (~> 2.5, >= 2.5.2)
+      nokogiri (~> 1.4)
+      ntlm-http (~> 0.1, >= 0.1.1)
+      webrobots (~> 0.0, >= 0.0.9)
     method_source (0.8.1)
     mime-types (1.21)
     multi_json (1.6.1)
     mysql2 (0.3.11)
+    net-http-digest_auth (1.2.1)
+    net-http-persistent (2.8)
     nokogiri (1.5.6)
+    ntlm-http (0.1.1)
     polyglot (0.3.3)
     pry (0.9.12)
       coderay (~> 1.0.5)
@@ -146,10 +159,6 @@ GEM
     rake (10.0.3)
     rdoc (3.12.2)
       json (~> 1.4)
-    rfeedfinder (0.9.13)
-      hoe (>= 1.7.0)
-      hpricot (>= 0.6)
-      htmlentities (>= 4.0.0)
     rspec-core (2.12.2)
     rspec-expectations (2.12.1)
       diff-lcs (~> 1.1.3)
@@ -196,6 +205,10 @@ GEM
     uglifier (1.3.0)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)
+    unf (0.0.5)
+      unf_ext
+    unf_ext (0.0.6)
+    webrobots (0.1.1)
     websocket (1.0.7)
     xpath (1.0.0)
       nokogiri (~> 1.3)
@@ -209,8 +222,10 @@ DEPENDENCIES
   capybara
   coffee-rails (~> 3.2.1)
   factory_girl_rails
+  feed_searcher
   feedzirra!
   haml
+  hpricot
   i18n-js
   launchy
   mysql2
@@ -218,7 +233,6 @@ DEPENDENCIES
   pry-doc
   pry-rails
   rails (= 3.2.12)
-  rfeedfinder
   rspec-rails
   sass-rails (~> 3.2.3)
   simplecov

--- a/app/controllers/api/feed_controller.rb
+++ b/app/controllers/api/feed_controller.rb
@@ -12,7 +12,7 @@ class Api::FeedController < ApplicationController
 
   def discover
     feeds = []
-    Rfeedfinder.feeds(params[:url]).each do |feedlink|
+    FeedSearcher.search(params[:url]).each do |feedlink|
       if feed = Feed.find_by_feedlink(feedlink)
         result = {
           :subscribers_count => feed.subscribers_count,

--- a/app/controllers/subscribe_controller.rb
+++ b/app/controllers/subscribe_controller.rb
@@ -16,7 +16,7 @@ class SubscribeController < ApplicationController
     feeds = []
     # params[:url] is http:/example.com because of squeeze("/")
     @url = request.original_fullpath.slice(11..-1) unless params[:url].blank?
-    Rfeedfinder.feeds(@url).each do |feedlink|
+    FeedSearcher.search(@url).each do |feedlink|
       if feed = Feed.find_by_feedlink(feedlink)
         if sub = @member.subscribed(feed)
           feed[:subscribe_id] = sub.id

--- a/lib/fastladder.rb
+++ b/lib/fastladder.rb
@@ -100,5 +100,3 @@ module Fastladder
 
   module_function :fetch, :simple_fetch
 end
-
-require 'fastladder/feedfinder'

--- a/lib/fastladder/feedfinder.rb
+++ b/lib/fastladder/feedfinder.rb
@@ -1,7 +1,0 @@
-require "rfeedfinder"
-
-def Rfeedfinder.open_doc(link, options = {})
-  html_body = Fastladder::simple_fetch(link.to_s)
-  return nil unless html_body
-  Hpricot(html_body, :xml => true)
-end


### PR DESCRIPTION
I created a tiny gem to put an END to Rfeedfinder a while ago.
What do you think of this?
https://github.com/r7kamura/feed_searcher

In addition, I found that hpricot is used in this rails application but not written in Gemfile.
Because Rfeedfinder was using this, it had worked without any problems.
