### PR TITLE
Fix signup: secondary user cannot signup

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -34,7 +34,7 @@ class Member < ActiveRecord::Base
   validates_confirmation_of :password, :if => :password_required?
   validates_length_of :username, :within => 3..40
   validates_uniqueness_of :username, :case_sensitive => false
-  validates_uniqueness_of :auth_key
+  validates_uniqueness_of :auth_key, :allow_nil => true
   before_save :encrypt_password
   
   # prevents a user from submitting a crafted form that bypasses activation

--- a/spec/requests/signup_stories_spec.rb
+++ b/spec/requests/signup_stories_spec.rb
@@ -10,10 +10,24 @@ describe "SignupStories" do
       fill_in 'member_password', with: 'mala'
       fill_in 'member_password_confirmation', with: 'mala'
       click_on 'Sign Up'
-
       # expect(page.body).to match(/Thanks for signing up!/) # TODO: reader#index rendered without layout (notice flash does not rendered)
     }.to change {
       Member.count
     }.by(1)
   end
+
+  it "sign up as a second member" do
+    Member.create!(username: "bulkneets", password: "mala", password_confirmation: "mala")
+    expect {
+      visit "/signup"
+      fill_in 'member_username', with: '_bulkneets'
+      fill_in 'member_password', with: 'mala'
+      fill_in 'member_password_confirmation', with: 'mala'
+      click_on 'Sign Up'
+      # expect(page.body).to match(/Thanks for signing up!/) # TODO: reader#index rendered without layout (notice flash does not rendered)
+    }.to change {
+      Member.count
+    }.by(1)
+  end
+
 end


### PR DESCRIPTION
Skip auth_key validation for default value(nil).
## 

auth_keyがnilのユーザが一人でもいるとsignupできなかったので、一意性チェックの対象からnilをはずしました。
