### PR TITLE
Fix RSS auto discovery when relative path feed

### DIFF
--- a/app/controllers/api/feed_controller.rb
+++ b/app/controllers/api/feed_controller.rb
@@ -12,7 +12,9 @@ class Api::FeedController < ApplicationController
 
   def discover
     feeds = []
-    FeedSearcher.search(params[:url]).each do |feedlink|
+    url = URI.parse(params[:url])
+    FeedSearcher.search(url.to_s).each do |feedlink|
+      feedlink = (url + feedlink).to_s
       if feed = Feed.find_by_feedlink(feedlink)
         result = {
           :subscribers_count => feed.subscribers_count,


### PR DESCRIPTION
Auto discoveryで抜き出された feed の URI が相対パスであった場合に例外が発生してしまっていたのを修正しました。確認をお願いします。
