### PR TITLE
Add encoding column in setting for SQLite3

### DIFF
--- a/config/database.yml.sqlite3
+++ b/config/database.yml.sqlite3
@@ -2,6 +2,7 @@
 #   gem install sqlite3-ruby (not necessary on OS X Leopard)
 development:
   adapter: sqlite3
+  encoding: utf8
   database: db/development.sqlite3
   timeout: 5000
 
@@ -10,10 +11,12 @@ development:
 # Do not set this db to the same as development or production.
 test:
   adapter: sqlite3
+  encoding: utf8
   database: db/test.sqlite3
   timeout: 5000
 
 production:
   adapter: sqlite3
+  encoding: utf8
   database: db/production.sqlite3
   timeout: 5000


### PR DESCRIPTION
SQLite3 を使っていると

```
incompatible character encodings: ASCII-8BIT and UTF-8
```

というエラーが出てしまっていたので。
