### PR TITLE
Support application/rdf+xml as feed resource

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'haml'
 gem 'feedzirra', :git => "https://github.com/pauldix/feedzirra"
 gem 'opml', github: 'fastladder/opml'
 gem 'verification', github: 'sikachu/verification'
-gem 'feed_searcher', '~> 0.0.3'
+gem 'feed_searcher', '>= 0.0.4'
 gem 'nokogiri'
 gem "mini_magick"
 gem "addressable", :require => "addressable/uri"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,8 +79,8 @@ GEM
     crack (0.3.2)
     curb (0.8.3)
     diff-lcs (1.1.3)
-    domain_name (0.5.8)
-      unf (~> 0.0.3)
+    domain_name (0.5.9)
+      unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (1.4.0)
       multi_json (~> 1.0)
@@ -89,7 +89,7 @@ GEM
     factory_girl_rails (1.7.0)
       factory_girl (~> 2.6.0)
       railties (>= 3.0.0)
-    feed_searcher (0.0.3)
+    feed_searcher (0.0.4)
       mechanize (>= 1.0.0)
       nokogiri
     ffi (1.4.0)
@@ -217,7 +217,7 @@ GEM
     uglifier (1.3.0)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)
-    unf (0.0.5)
+    unf (0.1.0)
       unf_ext
     unf_ext (0.0.6)
     webmock (1.11.0)
@@ -238,7 +238,7 @@ DEPENDENCIES
   capybara
   coffee-rails (~> 3.2.1)
   factory_girl_rails
-  feed_searcher (~> 0.0.3)
+  feed_searcher (>= 0.0.4)
   feedzirra!
   haml
   i18n-js


### PR DESCRIPTION
By this change, an URL with one of the following MIME types will be recognized as a feed resource:
- application/atom+xml
- application/rdf+xml
- application/rss+xml

This just updates FeedSearcher to v0.0.4, which supports what the title says.
For more detail on MIME types of feed, my recent blog post might help you.
- http://r7kamura.hatenablog.com/entry/2013/03/18/012636
- https://github.com/fastladder/feed_searcher/compare/v0.0.3...v0.0.4
