### PR TITLE
fix crawler for redirected URL(e.g. http://b.hatena.ne.jp/hotentry.rss)

### DIFF
--- a/lib/fastladder/crawler.rb
+++ b/lib/fastladder/crawler.rb
@@ -106,7 +106,7 @@ module Fastladder
           break
 =end
         when Net::HTTPRedirection
-          @logger.info "Redirect: #{feedlink} => #{response["location"]}"
+          @logger.info "Redirect: #{feed.feedlink} => #{response["location"]}"
           feed.feedlink = response["location"]
           feed.modified_on = nil
           feed.save


### PR DESCRIPTION
Though `script/crawler` are deprecated, I want to use it now.

今の段階でクローラをいじるのは微妙かと思いましたが、とりあえず動かしたかったので修正しました。
