### PR TITLE
Fix a subscribe page if has querystring

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,8 +41,16 @@ class ApplicationController < ActionController::Base
 
   # extract URL from request_path(e.g. /about/http://example.com)
   def url_from_path(name)
-    # params[name] is http:/example.com because of squeeze("/")
-    path = url_for(name => ".", :only_path => true)
-    request.original_fullpath.slice(path.size-1..-1)
+    if (url = params[name]).present?
+      if not (parsed_url = URI.parse(url)).is_a? URI::HTTP or parsed_url.host.nil?
+        url = nil
+      end
+    end
+    unless url.present?
+      # params[name] is http:/example.com because of squeeze("/")
+      path = url_for(name => ".", :only_path => true)
+      url = request.original_fullpath.slice(path.size-1..-1)
+    end
+    url
   end
 end

--- a/app/controllers/subscribe_controller.rb
+++ b/app/controllers/subscribe_controller.rb
@@ -4,18 +4,15 @@ class SubscribeController < ApplicationController
   # Ffeed = Struct.new('Candidates', :link, :feedlink, :title, :subscribers_count, :subscribe_id)
 
   def index
-    if (@url = params[:url]).present?
+    if params[:url].present?
       return self.confirm
     end
   end
   
   def confirm
-    if request.post?
-      return self.subscribe
-    end
     feeds = []
     # params[:url] is http:/example.com because of squeeze("/")
-    @url ||= url_from_path(:url) unless params[:url].blank?
+    @url = url_from_path(:url)
     FeedSearcher.search(@url).each do |feedlink|
       if feed = Feed.find_by_feedlink(feedlink)
         if sub = @member.subscribed(feed)
@@ -36,7 +33,6 @@ class SubscribeController < ApplicationController
     render :action => "confirm"
   end
 
-protected
   def subscribe
     unless params[:check_for_subscribe]
       flash[:notice] = "please check for subscribe"
@@ -50,7 +46,7 @@ protected
       folder_id = nil
     end
     options[:folder_id] = folder_id
-    params[:check_for_subscribe].values.each do |feedlink|
+    params[:check_for_subscribe].each do |feedlink|
       @member.subscribe_feed(feedlink, options)
     end
     # render :json => params.to_json

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Fastladder::Application.routes.draw do
   match 'api/:action' => 'api'
   get 'subscribe', :to => 'subscribe#index'
   get 'subscribe/*url', :to => 'subscribe#confirm', :as => :subscribe, :format => false
+  post 'subscribe/*url', :to => 'subscribe#subscribe', :format => false
   match 'about/*url' => 'about#index', as: :about, format: false
   match 'user/:login_name/:action' => 'user'
   match 'user/:login_name' => 'user#index', :as => 'user'


### PR DESCRIPTION
`/subscribe/?url=https%3A%2F%2Fgithub.com%2Ffastladder%2Ffastladder` のようにクエリーストリングを使った URI の指定で動作不具を起こしてしまっていたのを修正しました。`/subscribe` に対して GET メソッドないし POST メソッドで `params[:url]` が与えられた場合に `/subscribe/*url` に対してリダイレクトさせるような形にするのも良いかも知れません。
