### PR TITLE
Fix fetch body from RSS 2.0

### DIFF
--- a/lib/fastladder/crawler.rb
+++ b/lib/fastladder/crawler.rb
@@ -138,7 +138,7 @@ module Fastladder
           :feed_id => feed.id,
           :link => item.url || "",
           :title => item.title || "",
-          :body => item.content,
+          :body => item.content || item.summary,
           :author => item.author,
           :category => item.categories.first,
           :enclosure => nil,


### PR DESCRIPTION
19970c824b990557a2e131a1feab3a5d6032780d から `FeedNormalizer` を `Feedzirra` に置き換えた結果として、RSS 2.0 の本文取得が出来なくなってしまっていたのを修正しました。
