### PR TITLE
fix /user/name for production mode

### DIFF
--- a/app/views/user/index.html.erb
+++ b/app/views/user/index.html.erb
@@ -11,7 +11,7 @@
 <script type="text/javascript">
 var ApiKey = null;
 </script>
-<% javascript_include_tag "reader_subscribe" %>
+<%= javascript_include_tag "subscribe" %>
 
 <div id="content" class="page_user">
 <h2>User Information</h2>


### PR DESCRIPTION
fix `/user/:name` page for production mode.
It might be good to run `rake spec:features` with asset pipeline for finding bugs like this.

---

`/user/:username`がproduction modeで動かなかったので直しました。
こういうのをテストするために、asset pipelineを有効にして `rake spec:features` を走らせるようにしたほうがいいかも?
