### PR TITLE
Remove loadJS

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,11 +1,5 @@
 # Methods added to this helper will be available to all templates in the application.
 module ApplicationHelper
-  def loadJS(*filename)
-    filename.map {|str|
-      javascript_include_tag str
-    }.join("\n")
-  end
-
   def disp_users(num)
     "#{num} #{(num > 1 ? "users" : "user")}"
   end


### PR DESCRIPTION
今まで複数の JavaScript を読み込む為に使われていたヘルパーの `loadJS` はもう使われていませんよね。Assets Pipeline を使うようになって使われる事はもうないだろうと思われますので削除しました。
