### PR TITLE
Fix DEPRECATION WARNING on render with format included template name.

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -11,7 +11,7 @@ class AboutController < ApplicationController
       end 
     else
       respond_to do |format|
-        format.html { render file: "#{Rails.root}/public/404.html", status: :not_found }
+        format.html { render file: "#{Rails.root}/public/404", status: :not_found }
         format.json { render json: @feed.to_json } # for backward compatibility
         format.any { head :not_found }
       end 


### PR DESCRIPTION
DEPRECATION WARNING: Passing the format in the template name is
deprecated. Please pass render with :formats => [:html] instead.
