### PR TITLE
bump rails to 3.2.13

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :assets do
   gem 'sass-rails',   '~> 3.2.3'
   gem 'coffee-rails', '~> 3.2.1'
 
-  gem 'i18n-js'
+  gem 'i18n-js', github: 'fnando/i18n-js'
 
   # See https://github.com/sstephenson/execjs#readme for more supported runtimes
   # gem 'therubyracer', :platforms => :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,13 @@ GIT
       activesupport (~> 3.2.12)
 
 GIT
+  remote: git://github.com/fnando/i18n-js.git
+  revision: eeec14066b50f72876aa789c9b1f226172452798
+  specs:
+    i18n-js (2.1.2)
+      i18n
+
+GIT
   remote: git://github.com/sikachu/verification.git
   revision: 7c692e3cdb7e3c9dd075503baeb63a1022025f08
   specs:
@@ -101,8 +108,6 @@ GEM
     hike (1.2.1)
     http_parser.rb (0.5.3)
     i18n (0.6.1)
-    i18n-js (2.1.2)
-      i18n
     journey (1.0.4)
     json (1.7.7)
     konacha (2.5.1)
@@ -249,7 +254,7 @@ DEPENDENCIES
   feed_searcher (>= 0.0.4)
   feedzirra!
   haml
-  i18n-js
+  i18n-js!
   konacha
   launchy
   mini_magick


### PR DESCRIPTION
activesupport の指定で i18n が 0.6.1 に戻っていますが、ざっくり眺めて問題なさそうだと判断しました。
