### PR TITLE
Bump up the version of feed_searcher to 0.0.5 or higher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'haml'
 gem 'feedzirra', :git => "https://github.com/pauldix/feedzirra"
 gem 'opml', github: 'fastladder/opml'
 gem 'verification', github: 'sikachu/verification'
-gem 'feed_searcher', '>= 0.0.4'
+gem 'feed_searcher', '>= 0.0.5'
 gem 'nokogiri'
 gem "mini_magick"
 gem "addressable", :require => "addressable/uri"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,7 @@ GEM
       railties (>= 3.0.0)
     faye-websocket (0.4.7)
       eventmachine (>= 0.12.0)
-    feed_searcher (0.0.4)
+    feed_searcher (0.0.5)
       mechanize (>= 1.0.0)
       nokogiri
     ffi (1.4.0)
@@ -252,7 +252,7 @@ DEPENDENCIES
   capybara
   coffee-rails (~> 3.2.1)
   factory_girl_rails
-  feed_searcher (>= 0.0.4)
+  feed_searcher (>= 0.0.5)
   feedzirra!
   haml
   i18n-js!


### PR DESCRIPTION
From feed_searcher v0.0.5, it can recognize also the passed url as a feed url.
FYI: https://github.com/fastladder/feed_searcher/compare/v0.0.4...master
