### PR TITLE
Add ruby-head to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 rvm:
 - 1.9.3
 - 2.0.0
+- ruby-head
 branches:
   only:
     - master


### PR DESCRIPTION
Travis CI にて ruby-head (trunk) でビルドするタスクを追加しました。
手元の環境ではテストが全通過する && 実際に動くことを確認済です。
