### PR TITLE
Gemfile format unity

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'mysql2'
 gem 'haml'
 
 # current release version has no `feed.description` method. this is why :git used
-gem 'feedzirra', git: "https://github.com/pauldix/feedzirra"
+gem 'feedzirra', github: 'pauldix/feedzirra'
 gem 'opml', github: 'fastladder/opml'
 gem 'verification', github: 'sikachu/verification'
 gem 'feed_searcher', '>= 0.0.6'


### PR DESCRIPTION
細かいのですがフォーマットの不揃いが気になったので、gem を GitHub から取得する際には `:github` を使う形で揃えました。
