### PR TITLE
refactor api/pins

### DIFF
--- a/app/controllers/api/pin_controller.rb
+++ b/app/controllers/api/pin_controller.rb
@@ -5,27 +5,31 @@ class Api::PinController < ApplicationController
   #verify_json :params => :link, :only => :remove
   skip_before_filter :verify_authenticity_token
 
+  module ErrorCode
+    NOT_FOUND = 2
+  end
+
   def all
-    render :json => @member.pins.to_json
+    render json: current_member.pins.to_json
   end
 
   def add
     link = params[:link]
     title = params[:title]
-    @member.pins.create(:link => link, :title => title)
+    current_member.pins.create(link: link, title: title)
     render_json_status(true)
   end
 
   def remove
-    unless pin = @member.pins.find_by_link(params[:link])
-      return render_json_status(false, 2)
+    unless pin = current_member.pins.find_by_link(params[:link])
+      return render_json_status(false, ErrorCode::NOT_FOUND)
     end
     pin.destroy
     render_json_status(true)
   end
 
   def clear
-    Pin.delete_all(:member_id => @member.id)
+    current_member.pins.destroy_all
     render_json_status(true)
   end
 end

--- a/spec/controllers/api/pin_controller_spec.rb
+++ b/spec/controllers/api/pin_controller_spec.rb
@@ -18,12 +18,33 @@ describe Api::PinController do
       post :remove, { link: 'http://la.ma.la/blog/diary_200810292006.htm' }, { member_id: @member.id }
       expect(response.body).to be_json
     end
+
+    context "pin not found" do
+      it 'return errorcode' do
+        post :remove, { link: 'http://la.ma.la/blog/diary_200810292006.htm' }, { member_id: @member.id }
+        expect(JSON.parse(response.body)).to include("ErrorCode" => Api::PinController::ErrorCode::NOT_FOUND)
+      end
+    end
+    context "pin exists" do
+      let(:link) { 'http://la.ma.la/blog/diary_200810292006.htm' }
+      before { FactoryGirl.create(:pin, member: @member, link: link) }
+      it 'return success' do
+        post :remove, { link: link }, { member_id: @member.id }
+        expect(JSON.parse(response.body)).to include("isSuccess" => true)
+      end
+    end
   end
 
   describe 'POST /clear' do
+    before { FactoryGirl.create(:pin, member: @member) }
     it 'renders json' do
       post :clear, {}, { member_id: @member.id }
       expect(response.body).to be_json
+    end
+    it 'delete all pins' do
+      expect {
+        post :clear, {}, { member_id: @member.id }
+      }.to change{ @member.pins.count }.from(1).to(0)
     end
   end
 end


### PR DESCRIPTION
- use `current_member`
- use 1.9 style Hash syntax
- remove magic-number of ErrorCode
- use Member#pins association to find destroy pins
