### PR TITLE
add spec of import#fetch, and fix bug.

### DIFF
--- a/app/controllers/import_controller.rb
+++ b/app/controllers/import_controller.rb
@@ -22,8 +22,8 @@ class ImportController < ApplicationController
         feedlink = attributes["xml_url"]
         feed = Feed.find_by_feedlink(feedlink)
         item = {}
-        item[:title] = attributes["title"] or attributes["text"] or feedlink
-        item[:link] = attributes["url"] or feedlink
+        item[:title] = attributes["title"] || attributes["text"] || feedlink
+        item[:link] = attributes["url"] || attributes["html_url"] || feedlink
         item[:feedlink] = feedlink
         item[:subscribed] = feed.present? ? current_member.subscribed(feed) : false
         item

--- a/spec/controllers/import_controller_spec.rb
+++ b/spec/controllers/import_controller_spec.rb
@@ -10,5 +10,21 @@ describe ImportController do
       Fastladder.should_receive(:simple_fetch).with('http://example.com') { '<opml/>' }
       post :fetch, { url: 'http://example.com' }, { member_id: @member.id }
     end
+
+    context "assigns" do
+      include_context(:use_stub_opml)
+      it "assigns folder" do
+        post :fetch, { url: 'http://example.com' }, { member_id: @member.id }
+        expect(assigns[:folders].keys).to include("Subscriptions")
+      end
+      it "assigns item" do
+        post :fetch, { url: 'http://example.com' }, { member_id: @member.id }
+        item = assigns[:folders]["Subscriptions"][0]
+        expect(item).to include("title" => "Recent Commits to fastladder:master")
+        expect(item).to include("link" => "https://github.com/fastladder/fastladder/commits/master")
+        expect(item).to include("feedlink" => "https://github.com/fastladder/fastladder/commits/master.atom")
+        expect(item).to include("subscribed" => false)
+      end
+    end
   end
 end

--- a/spec/stubs/opml
+++ b/spec/stubs/opml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<opml version="1.0">
+<head>
+  <title>onk's Subscriptions</title>
+  <ownerName>onk</ownerName>
+</head>
+<body>
+<outline title="Subscriptions">
+  <outline title="onk">
+    <outline title="Recent Commits to fastladder:master" htmlUrl="https://github.com/fastladder/fastladder/commits/master" type="rss" xmlUrl="https://github.com/fastladder/fastladder/commits/master.atom" />
+  </outline>
+</outline>
+</body></opml>

--- a/spec/support/use_stub_opml.rb
+++ b/spec/support/use_stub_opml.rb
@@ -1,0 +1,12 @@
+shared_context :use_stub_opml do
+  before {
+    Fastladder.stub(:simple_fetch).and_return(read_stub_file("opml"))
+  }
+
+  private
+  def read_stub_file(filename)
+    stub_root_dir = File.expand_path(File.dirname(__FILE__) + "/../../spec/stubs")
+    open("#{stub_root_dir}/#{filename}").read
+  end
+end
+


### PR DESCRIPTION
``` ruby
b = nil
c = true
a = b or c
a #=> nil
```

I prefer `or` to `||`.
