### PR TITLE
Fix wrong parameter check for /api/feed/subscribe

### DIFF
--- a/app/controllers/api/feed_controller.rb
+++ b/app/controllers/api/feed_controller.rb
@@ -1,7 +1,7 @@
 class Api::FeedController < ApplicationController
   before_filter   :login_required_api
   params_required :url         , only: :discover
-  params_required :subscribe_id, only: :subscribe
+  params_required :feedlink, only: :subscribe
   params_required :subscribe_id, only: [:unsubscribe, :update, :move]
   params_required [ :subscribe_id, :rate   ], only: :set_rate
   params_required [ :subscribe_id, :ignore ], only: :set_notify

--- a/spec/controllers/api/feed_controller_spec.rb
+++ b/spec/controllers/api/feed_controller_spec.rb
@@ -33,7 +33,7 @@ describe Api::FeedController do
 
   describe 'POST /subscribe' do
     it 'renders json' do
-      post :subscribe, { feedlink: @feed.feedlink, subscribe_id: @subscription.id }, { member_id: @member.id }
+      post :subscribe, { feedlink: @feed.feedlink }, { member_id: @member.id }
       expect(response.body).to be_json
     end
 


### PR DESCRIPTION
POST data from browser to /api/feed/subscribe is such:

```
feedlink:https://github.com/mitchellh/vagrant/commits/master.atom
ApiKey:
```
