### PR TITLE
Kill some ActiveRecord deprecation warnings

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -163,7 +163,7 @@ class ApiController < ApplicationController
 protected
   def find_sub
     @id = (params[:subscribe_id] || params[:id] || 0).to_i
-    unless @sub = @member.subscriptions.find_by_id(@id, include: :feed)
+    unless @sub = @member.subscriptions.includes(:feed).find_by_id(@id)
       render NOTHING
       return false
     end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -32,7 +32,11 @@ class Feed < ActiveRecord::Base
 
   scope :has_subscriptions, ->{ where("subscribers_count > 0") }
   scope :crawlable, ->{
-    includes(:crawl_status).has_subscriptions.merge(CrawlStatus.status_ok).merge(CrawlStatus.expired(Settings.crawl_interval.minutes))
+    includes(:crawl_status).
+      joins(:crawl_status).
+      has_subscriptions.
+      merge(CrawlStatus.status_ok).
+      merge(CrawlStatus.expired(Settings.crawl_interval.minutes))
   }
 
   def self.initialize_from_uri(uri)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -26,7 +26,7 @@ class Item < ActiveRecord::Base
 
   before_save :create_digest, :fill_datetime, :default_values
 
-  scope :stored_since, ->(viewed_on){ viewed_on ? where("stored_on >= ?", viewed_on) : scoped }
+  scope :stored_since, ->(viewed_on){ viewed_on ? where("stored_on >= ?", viewed_on) : all }
   scope :recent, ->(limit = nil, offset = nil){ order("created_on DESC, id DESC").limit(limit).offset(offset) }
 
   def default_values


### PR DESCRIPTION
いくつか Rails 4 (ActiveRecord 4) にアップデートした関連で deprecation warning が出ていたのでつぶしました。
- use `.all` instead of `.scope`
- use `.joins` for `.includes` explicitly
- do not use options in `.find_by_foo`
