### PR TITLE
Allow authentication by api_key

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,7 +58,15 @@ class ApplicationController < ActionController::Base
   private
 
   def current_member
-    @member ||= Member.where(id: session[:member_id]).first
+    @member ||= find_current_member_by_session || find_current_member_by_auth_key
+  end
+
+  def find_current_member_by_session
+    session[:member_id] && Member.find_by(id: session[:member_id])
+  end
+
+  def find_current_member_by_auth_key
+    params[:auth_key].presence && Member.find_by(auth_key: params[:auth_key])
   end
 
   def self.params_required(params, options = {})

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -13,9 +13,22 @@ describe ApplicationController do
     end
 
     context 'Member exists' do
-      it 'renders 200' do
-        get :index, { }, { member_id: member.id }
-        expect(response).to be_success
+      context 'session[:member_id] is given' do
+        it 'renders 200' do
+          get :index, { }, { member_id: member.id }
+          expect(response).to be_success
+        end
+      end
+
+      context 'params[:auth_key] is given' do
+        before do
+          member.set_auth_key
+        end
+
+        it 'renders 200' do
+          get :index, { auth_key: member.auth_key }
+          expect(response).to be_success
+        end
       end
     end
 


### PR DESCRIPTION
Currently the authentication by api_key is only allowed in RpcController.
It would be useful if other API (e.g., /api/pin/all) can be accessed by api_key.
