### PR TITLE
[Sign Up] Error of a blank username

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
 <div id="container">
 <div class="navi">
 <h1 class="logo"><%= link_to "Fastladder", root_path %></h1>
-<% if current_member.present? -%>
+<% if current_member.present? and not current_member.errors -%>
 <ul>
 	<li>Wellcome <%= link_to current_member.username, user_path(current_member.username) %></li>
 	<li><%= link_to "My Feeds", reader_path %></li>


### PR DESCRIPTION
![2014-10-03 2 38 12 am](https://cloud.githubusercontent.com/assets/39830/4495373/efa3712a-4a5a-11e4-9008-3006d008fedc.png)
1. Visit `/signup`
2. Click `[Sign Up]`

![2014-10-03 2 14 05 am](https://cloud.githubusercontent.com/assets/39830/4495333/8c37f0f2-4a5a-11e4-9402-0918ae699f8f.png)

```
Started POST "/members" for 127.0.0.1 at 2014-10-03 02:13:29 +0900
Processing by MembersController#create as HTML
  Parameters: {"utf8"=>"✓", "authenticity_token"=>"hk4zsTY0djU/GhWo76EnzJ9wwxIxaNZVmGCrTSJdmHM=", "member"=>{"username"=>"", "password"=>"[FILTERED]", "password_confirmation"=>"[FILTERED]"}, "commit"=>"Sign Up"}
   (0.4ms)  begin transaction
  Member Exists (0.4ms)  SELECT  1 AS one FROM "members"  WHERE LOWER("members"."username") = LOWER('') LIMIT 1
   (0.2ms)  rollback transaction
  Rendered members/new.html.haml within layouts/application (4.8ms)
Completed 500 Internal Server Error in 207ms

ActionView::Template::Error (No route matches {:action=>"index", :controller=>"user", :login_name=>""} missing required keys: [:login_name]):
    15: <h1 class="logo"><%= link_to "Fastladder", root_path %></h1>
    16: <% if current_member.present? -%>
    17: <ul>
    18:     <li>Wellcome <%= link_to current_member.username, user_path(current_member.username) %></li>
    19:     <li><%= link_to "My Feeds", reader_path %></li>
    20:     <li><%= link_to "Account", account_index_path %></li>
    21:     <li><%= link_to "Sign Out", logout_path %></li>
  app/views/layouts/application.html.erb:18:in `_app_views_layouts_application_html_erb__3429277943917853170_70124438573740'
  app/controllers/members_controller.rb:19:in `rescue in create'
  app/controllers/members_controller.rb:7:in `create'


  Rendered /Users/kstg/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/actionpack-4.1.6/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (3.2ms)
  Rendered /Users/kstg/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/actionpack-4.1.6/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (2.8ms)
  Rendered /Users/kstg/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/actionpack-4.1.6/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb within rescues/layout (25.9ms)
```

:arrow_down:

![2014-10-03 2 12 19 am](https://cloud.githubusercontent.com/assets/39830/4495360/caeff916-4a5a-11e4-966a-554dea9d6e2e.png)
