### PR TITLE
Fix item digest calculation

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -44,7 +44,7 @@ class Item < ActiveRecord::Base
     str = "#{self.title}#{self.body}"
     str.gsub!(%r{<br clear="all"\s*/>\s*<a href="http://rss\.rssad\.jp/(.*?)</a>\s*<br\s*/>}im, "")
     str = str.gsub(/\s+/, "")
-    digest = Digest::SHA1.hexdigest(str)
+    digest = Digest::SHA1.hexdigest([self.feed.feedlink, self.link, str].join)
     self.digest = digest
   end
 

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -6,6 +6,7 @@ FactoryGirl.define do
   sequence(:item_guid_seq) {|n| "guid#{n}" }
 
   factory :item do
+    feed
     link { FactoryGirl.generate(:item_link_seq) }
     title '最速インターフェース研究会 :: 近況'
     body '観光目的で7ヶ月ほど京都旅行に行っていた。<br>祇園祭楽しかったですね。'

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -78,4 +78,49 @@ describe Item do
       expect(item.guid).to eq(item.link)
     end
   end
+
+  describe '#digest' do
+    let(:feed) { FactoryGirl.create(:feed) }
+    let(:item) { FactoryGirl.create(:item, feed: feed) }
+
+    context 'if feedlink is different' do
+      let(:feed2) { FactoryGirl.create(:feed) }
+
+      it 'calculates different digest' do
+        expect {
+          item.update_attributes(feed: feed2)
+        }.to change { item.digest }
+      end
+    end
+
+    context 'if link is different' do
+      let(:link) { FactoryGirl.generate(:item_link_seq) }
+
+      it 'calculates different digest' do
+        expect {
+          item.update_attributes(link: link)
+        }.to change { item.digest }
+      end
+    end
+
+    context 'if title is different' do
+      let(:title) { item.title.reverse }
+
+      it 'calculates different digest' do
+        expect {
+          item.update_attributes(title: title)
+        }.to change { item.digest }
+      end
+    end
+
+    context 'if body is different' do
+      let(:body) { item.body.reverse }
+
+      it 'calculates different digest' do
+        expect {
+          item.update_attributes(body: body)
+        }.to change { item.digest }
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://github.com/fastladder/fastladder/issues/144

rpc_controller にフィードアイテムのデータを POST するクローラーは feedlink, link, title, body 全ての情報を知っているとみなして、 item.digest の計算方法を変えてみました。どうでしょうか？
