### PR TITLE
stop using thin for development web application server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,6 @@ group :test, :development do
   gem 'konacha'
   gem 'poltergeist'
   gem 'sinon-rails'
-  gem 'thin'
 end
 
 # Use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,13 +72,11 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     curb (0.8.6)
-    daemons (1.1.9)
     diff-lcs (1.2.5)
     docile (1.1.5)
     domain_name (0.5.21)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
-    eventmachine (1.0.3)
     execjs (2.2.1)
     factory_girl (4.4.0)
       activesupport (>= 3.0.0)
@@ -243,10 +241,6 @@ GEM
     subexec (0.2.3)
     term-ansicolor (1.3.0)
       tins (~> 1.0)
-    thin (1.6.2)
-      daemons (>= 1.0.9)
-      eventmachine (>= 1.0.0)
-      rack (>= 1.0.0)
     thor (0.19.1)
     thread_safe (0.3.4)
     tilt (1.4.1)
@@ -312,7 +306,6 @@ DEPENDENCIES
   simplecov-rcov
   sinon-rails
   sqlite3
-  thin
   turbolinks
   uglifier (>= 1.3.0)
   unicorn


### PR DESCRIPTION
eventmachine 1.0.3 が ruby 2.2.0 でコンパイルできないため
