### PR TITLE
Fix crawler to save modified items

### DIFF
--- a/lib/fastladder/crawler.rb
+++ b/lib/fastladder/crawler.rb
@@ -197,7 +197,7 @@ module Fastladder
             old_item.stored_on = item.stored_on
             result[:updated_items] += 1
           end
-          update_columns = [:link, :title, :body, :author, :category, :enclosure, :enclosure_type, :digest, :stored_on, :modified_on]
+          update_columns = %w(link title body author category enclosure enclosure_type digest modified_on)
           old_item.attributes = item.attributes.select{ |column, value| update_columns.include? column }
           old_item.save
         else


### PR DESCRIPTION
更新されたエントリの情報が正しく保存されないバグを修正しました。
- item.attributes で返る Hash のキーは文字列なので、update_columns を文字列配列に変更
- 更新された item だけ stored_on を更新したいので、update_columns から stored_on を削除
