### PR TITLE
add dependent option to has_one/has_many association.

### DIFF
--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -21,10 +21,10 @@ require "open-uri"
 require "tempfile"
 
 class Feed < ActiveRecord::Base
-  has_one :crawl_status
-  has_one :favicon
-  has_many :items
-  has_many :subscriptions
+  has_one :crawl_status, dependent: :destroy
+  has_one :favicon, dependent: :destroy
+  has_many :items, dependent: :delete_all
+  has_many :subscriptions, dependent: :destroy
   #has_many :members, through: :subscriptions
   #has_many :folders, through: :subscriptions
 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -23,9 +23,9 @@ class Member < ActiveRecord::Base
   attr_accessor :password
   serialize :config_dump
 
-  has_many :folders
-  has_many :subscriptions
-  has_many :pins
+  has_many :folders, dependent: :delete_all
+  has_many :subscriptions, dependent: :destroy
+  has_many :pins, dependent: :delete_all
 
   validates_presence_of :username
   validates_presence_of :password, if: :password_required?


### PR DESCRIPTION
basically, `dependent: :delete_all`.
Subscription model has after_destroy callback.
so `Member#subscriptions` and `Feed#subscriptions` associations with `dependent: :destroy`.

---

has_one 関連は `dependent: :destroy`。
has_many 関連は 1 件ずつ destroy していると不要な負荷を与えるので基本的には `dependent: :delete_all`。
before_destroy, after_destroy callback を子の側で使っている場合のみ
`dependent: :destroy` にするという方針で設定しました。
