### PR TITLE
Fix crawler to skip guid duplicated items

### DIFF
--- a/lib/fastladder/crawler.rb
+++ b/lib/fastladder/crawler.rb
@@ -180,7 +180,7 @@ module Fastladder
     end
 
     def reject_duplicated(feed, items)
-      items.reject { |item| feed.items.exists?(["guid = ? and digest = ?", item.id, item.digest]) }
+      items.uniq { |item| item.guid }.reject { |item| feed.items.exists?(["guid = ? and digest = ?", item.id, item.digest]) }
     end
 
     def delete_old_items_if_new_items_are_many(new_items_size)


### PR DESCRIPTION
フィード内に guid の重複するアイテムがあると、クロールのたびにそのアイテムが未読になってしまうので、最新のアイテムだけ生かすようにしてみました。
