### PR TITLE
Fix missing api key

### DIFF
--- a/app/views/share/index.html.erb
+++ b/app/views/share/index.html.erb
@@ -73,5 +73,6 @@
 </div>
 </div>
 
+<script type="text/javascript">var ApiKey = "<%= session[:session_id] %>";</script>
 <%= javascript_include_tag "share" %>
 

--- a/app/views/subscribe/confirm.html.erb
+++ b/app/views/subscribe/confirm.html.erb
@@ -104,5 +104,6 @@
 </div><!-- /content-inner -->
 </div><!-- /content -->
 
+<script type="text/javascript">var ApiKey = "<%= session[:session_id] %>";</script>
 <%= javascript_include_tag "subscribe" %>
 <script type="text/javascript">if(typeof init == "function") init();</script>

--- a/app/views/subscribe/index.html.erb
+++ b/app/views/subscribe/index.html.erb
@@ -19,4 +19,5 @@
 </div>
 </div>
 </div>
+<script type="text/javascript">var ApiKey = "<%= session[:session_id] %>";</script>
 <%= javascript_include_tag "subscribe" %>


### PR DESCRIPTION
share や subscription ページで ApiKey が未定義のためエラーとなるのを修正しました。
