### PR TITLE
fix gems order.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,8 +53,8 @@ gem 'uglifier', '>= 1.3.0'
 
 group :development do
   gem 'annotate'
-  gem 'pry-doc'
   gem 'pry-rails'
+  gem 'pry-doc'
   gem 'quiet_assets'
 end
 


### PR DESCRIPTION
pry-rails より先に pry-doc を書くとエラーになっていたので修正しました。
https://github.com/banister/pry-doc/issues/3
