### PR TITLE
Fixed some bugs regarding feed subscription

### DIFF
--- a/app/assets/javascripts/lib/subscribe/subscribe.js
+++ b/app/assets/javascripts/lib/subscribe/subscribe.js
@@ -45,13 +45,13 @@ ReaderSubscribe.extend({
 	},
 	subscribe: function(option, callback){
 		var api = new LDR.API("/api/feed/subscribe");
-		var param = {};
-		api.post({
-			feedlink  : option.feedlink,
-			folder_id : option.folder_id,
-			rate      : option.rate,
-			"public"  : option["public"]
-		}, callback);
+		var param = {
+			feedlink	: option.feedlink,
+			rate			: option.rate,
+			"public"	: option["public"]
+		};
+		if(option.folder_id != "0" && option.folder_id != 0){ param.folder_id = option.folder_id; }
+		api.post(param, callback);
 	},
 	get_backurl: function(){
 		var base = ReaderSubscribe.get_baseurl();

--- a/app/views/subscribe/confirm.html.erb
+++ b/app/views/subscribe/confirm.html.erb
@@ -24,7 +24,7 @@
 			<% else -%>
 			<input type="checkbox" name="check_for_subscribe[]" value="<%=h feed.feedlink %>"<% if @feeds.size == 1 || i == 0 %> checked<% end %>>
 			<input type="hidden" name="feedlink" value="<%=h feed.feedlink %>" />
-			<%= link_to feed.title, feed.link, class: "subscribe_list", style: "background-image:url('#{favicon_path(feed.id)}')" %>
+			<%= link_to feed.title, feed.link, class: "subscribe_list", style: "background-image:url('#{favicon_path(feed.id || "missing")}')" %>
 			<span class="subscriber_count"><%= users_link(feed) %></span><br />
 			<%= link_to feed.feedlink, feed.feedlink, class: "feedlink" %>
 			<% end -%>


### PR DESCRIPTION
- Fixed an issue where routing bugs occurred trying to get favicon of unsaved feeds.
- Fixed an issue in which an invalid parameter was sent to the server when trying to subscribe to a feed without specifying a folder.

This patch allows users to subscribe to feeds.