### PR TITLE
Support zooming in browser

### DIFF
--- a/app/assets/javascripts/lib/reader/commands.js
+++ b/app/assets/javascripts/lib/reader/commands.js
@@ -760,7 +760,7 @@ var Control = {
     },
     next_item_offset: function(){
         var container = _$("right_container");
-        var sc = container.scrollTop;
+        var sc = Math.ceil(container.scrollTop);
         var top_offset = _$("right_body").offsetTop;
         var divs = _$("right_body").getElementsByTagName("h2");
         var active = (sc == 0) ? -1 : get_active_item();


### PR DESCRIPTION
ブラウザをズームさせると正しく次の記事に j で飛べていないという問題があった。

Linux で HiDPI 環境で Chrome を使うと、強制的にページをズームしたような感じになりやがって困るのでこのパッチを書いた。

100% これで HiDPI on Linux の問題が直るか正直よく分かってないんだけどとりあえず問題なさそうだし、この変更で既存の動作を破壊するということもないと思うので。