### PR TITLE
Fix undefined error in crawler

### DIFF
--- a/lib/fastladder/crawler.rb
+++ b/lib/fastladder/crawler.rb
@@ -160,7 +160,7 @@ module Fastladder
 
       items = cut_off(items)
       items = reject_duplicated(feed, items)
-      delete_old_items_if_new_items_are_many(items.size)
+      delete_old_items_if_new_items_are_many(feed, items.size)
       update_or_insert_items_to_feed(feed, items, result)
       update_unread_status(feed, result)
       update_feed_infomation(feed, parsed)
@@ -195,7 +195,7 @@ module Fastladder
       items.uniq { |item| item.guid }.reject { |item| feed.items.exists?(["guid = ? and digest = ?", item.guid, item.digest]) }
     end
 
-    def delete_old_items_if_new_items_are_many(new_items_size)
+    def delete_old_items_if_new_items_are_many(feed, new_items_size)
       return unless new_items_size > ITEMS_LIMIT / 2
       @logger.info "delete all items: #{feed.feedlink}"
       Items.where(feed_id: feed.id).delete_all


### PR DESCRIPTION
クローラの `delete_old_items_if_new_items_are_many` メソッドで引数が不足しており、
```
NameError: undefined local variable or method `feed'
```
というエラーが発生するようです。