### PR TITLE
Fix japanease chars in url at show GET /about/{feed.url}

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,7 +43,7 @@ class ApplicationController < ActionController::Base
   # extract URL from request_path(e.g. /about/http://example.com)
   def url_from_path(name)
     if (url = params[name]).present?
-      if not (parsed_url = URI.parse(url)).is_a? URI::HTTP or parsed_url.host.nil?
+      if not (parsed_url = Addressable::URI.parse(url)).is_a? Addressable::URI or parsed_url.host.nil?
         url = nil
       end
     end


### PR DESCRIPTION
URLに日本語を含むFeedを登録している場合に`GET /about/{feed.url}` にアクセスすると、RubyのURI.parseだと`URI::InvalidURIError`が発生して表示できない問題を修正しました。

`Addressable::URI.parse`を利用することにより日本語を含むURLをparseできるので、正常に表示することができました。

以下は問題が起こるようなフィードのURLです。

`https://news.google.com/news/rss/headlines/section/q/%E6%B8%8B%E8%B0%B7/%E6%B8%8B%E8%B0%B7?ned=us&hl=en&gl=US`

