### PR TITLE
Fix japaniase chars in domain

### DIFF
--- a/app/controllers/api/feed_controller.rb
+++ b/app/controllers/api/feed_controller.rb
@@ -10,8 +10,8 @@ class Api::FeedController < ApplicationController
 
   def discover
     feeds = []
-    url = URI.parse(params[:url])
-    FeedSearcher.search(url.to_s).each do |feedlink|
+    url = Addressable::URI.parse(params[:url])
+    FeedSearcher.search(url.normalize.to_s).each do |feedlink|
       feedlink = (url + feedlink).to_s
       if feed = Feed.find_by(feedlink: feedlink)
         result = {


### PR DESCRIPTION
FeedのURLに日本語ドメインが利用されている場合にfastladderに登録できない問題について修正しました。

この修正によりFeedのが日本語ドメインの場合、Punycodeに変換されて登録されます。
以後、内部ではPunycodeに変換されたURLで動作します。