### PR TITLE
Fix new item judgement

### DIFF
--- a/lib/fastladder/crawler.rb
+++ b/lib/fastladder/crawler.rb
@@ -160,7 +160,7 @@ module Fastladder
 
       items = cut_off(items)
       items = reject_duplicated(feed, items)
-      delete_old_items_if_new_items_are_many(feed, items.size)
+      delete_old_items_if_new_items_are_many(feed, items)
       update_or_insert_items_to_feed(feed, items, result)
       update_unread_status(feed, result)
       update_feed_infomation(feed, parsed)
@@ -195,8 +195,9 @@ module Fastladder
       items.uniq { |item| item.guid }.reject { |item| feed.items.exists?(["guid = ? and digest = ?", item.guid, item.digest]) }
     end
 
-    def delete_old_items_if_new_items_are_many(feed, new_items_size)
-      return unless new_items_size > ITEMS_LIMIT / 2
+    def delete_old_items_if_new_items_are_many(feed, items)
+      new_items = items.reject { |item| feed.items.exists?(["link = ? and digest = ?", item.link, item.digest]) }
+      return unless new_items.size > ITEMS_LIMIT / 2
       @logger.info "delete all items: #{feed.feedlink}"
       Item.where(feed_id: feed.id).delete_all
     end


### PR DESCRIPTION
以下のような問題を解決していったところ、crawlerで取得時にnew/old itemを判定する処理を正しく動作するように修正してみました。

## 毎回新規200件と表示される問題の修正

   299件itemが公開されているようなfeedだと、
   crowl毎に200件が新規(未読)itemとなるようなバグを確認していました。

   itemの既存/新規の判定が意図しない挙動で、大量の新規記事のFeedとして認識し、
   毎回すべてのitemを削除して、改めて新規のFeedとしてすべてのitemを取得しなおすような処理をしているようでした。

   これを解消しました。

### 修正1 既存と新規の検証処理が過去のリファクタで一部消失

   このリファクタリングの時に処理が1行抜けて、現状の問題となる挙動となってしまっているようです。
   https://github.com/fastladder/fastladder/commit/03fc0f7df3b4f8ce4f5bca0152a385d332051776#diff-1e7ec05d51bdaeca7eb54d2daf790905L166

   よって、この処理を復元する修正をしました。


### 修正2 digest検証の不具合と思われる挙動の修正

   さらに `Crawler#delete_old_items_if_new_items_are_many` では、digestを利用してitemの `既存 or 新規` を判定しています。

   検証の対象としているのが

     - 既にDBに保存されているdigest(Crawler#fixup_relative_links処理後のbody)
     - Crawler#fixup_relative_linksされる前の取得して加工処理前のbody

   を比較しているため、既存のitemでもdigestが異る確立が極めて高いという状態です。
   これは、おそらく意図しない挙動だと捉えましたので、修正を実施しました。

   これを解消するため、既にDBに保存されているdigestと同様に`Crawler#fixup_relative_links`処理後のbodyをdigestに用いるように修正しました。

   digestを作成するロジックがItemモデルとCrawlerと分散していたため、Crawler側を削除し、Itemモデル側の処理でdigest作成しています。

### 修正後

以上のような修正により299件のitemsを公開しているようなFeedで、正常に新規の記事(1件ならば1件)が表示されるようになりました。
