### PR TITLE
Refactor crawler and add spec

### DIFF
--- a/lib/fastladder/crawler.rb
+++ b/lib/fastladder/crawler.rb
@@ -200,9 +200,13 @@ module Fastladder
       items.uniq { |item| item.guid }.reject { |item| feed.items.exists?(["guid = ? and digest = ?", item.guid, item.digest]) }
     end
 
+    def new_items_count(feed, items)
+      items.reject { |item| feed.items.exists?(["link = ? and digest = ?", item.link, item.digest]) }.size
+    end
+
     def delete_old_items_if_new_items_are_many(feed, items)
-      new_items = items.reject { |item| feed.items.exists?(["link = ? and digest = ?", item.link, item.digest]) }
-      return unless new_items.size > ITEMS_LIMIT / 2
+      new_items_size = new_items_count(feed, items)
+      return unless new_items_size > ITEMS_LIMIT / 2
       @logger.info "delete all items: #{feed.feedlink}"
       Item.where(feed_id: feed.id).delete_all
     end

--- a/spec/lib/fastladder/crawler_spec.rb
+++ b/spec/lib/fastladder/crawler_spec.rb
@@ -47,4 +47,29 @@ describe 'Fastladder::Crawler' do
       expect(doc.css('a[href="http://example.com/bundler/bundler/tree/1-9-stable"]').size).to eq(1)
     end
   end
+
+  describe '#new_items_count' do
+    let(:items) { crawler.send(:build_items, feed, parsed) }
+    let(:parsed) { Feedjira::Feed.parse(source.body) }
+    let(:source) { double('HTTP response', body: atom_body) }
+    let(:atom_body) { File.read(File.expand_path('../../fixtures/github.private.atom', __dir__)) }
+
+    before do
+      feed.feedlink = 'http://example.com/private.atom'
+      feed.save!
+      # Disable favicon fetch
+      allow(feed).to receive(:favicon_list).and_return([])
+    end
+
+    it 'find new item' do
+      expect(crawler.send(:new_items_count, feed, items)).to eq(1)
+    end
+
+    context 'not updated feed since last update feed' do
+      before { crawler.send(:update, feed, source) }
+      it 'not find new item' do
+        expect(crawler.send(:new_items_count, feed, items)).to eq(0)
+      end
+    end
+  end
 end


### PR DESCRIPTION
#245 あたりの修正に対するspecを追加しました。

追加するにあたり、メソッドの引数の粒度 (feed, items, parsedなど) を揃えるリファクタリングを実施し、内部のテストを実施しやすくしました。