### PR TITLE
Fix undefined category method

### DIFF
--- a/lib/fastladder/crawler.rb
+++ b/lib/fastladder/crawler.rb
@@ -148,7 +148,7 @@ module Fastladder
                              title: item.title || "",
                              body: fixup_relative_links(feed, item.content || item.summary),
                              author: item.author,
-                             category: item.categories.first,
+                             category: item.try(:categories).try(:first),
                              enclosure: nil,
                              enclosure_type: nil,
                              stored_on: Time.now,


### PR DESCRIPTION
発生するエラー
```
NoMethodError: undefined method `categories' for #<Feedjira::Parser::ITunesRSSItem:0x00007fc8748baf58>
```
RSS Feed のURL: http://japanese.engadget.com/rss.xml

このエラーによって、crowlerがこのフィードのデータを取得することができていません。
この問題を調べ、修正しました。

この問題がおこるのはレアなフィードだと思うので、
メンテナンス性とシンプルさを重視した動作の挙動を提案します。

## 解決方法の提案

実際に利用しているfastladderの `item.category` のデータをいくつか確認したところ `nil` となっているデータが多くありました。
   多くのitemがcategory elementは存在していないことが実態のようです。

であれば、

     - `Feedjira::Parser::ITunesRSS`が利用されるフィードは稀
     - 実際のところcategory elementも存在してない
     - category elementが存在したとしても`Feedjira::Parser::ITunesRSS`だと特殊なこと

以上を考慮して

categories methodが存在しなければ、`category`の値は `nil` としてしまうというのが実運用上あまり問題にならずにcrowlもできるのではないでしょうか?


## 却下した解決方法

初期化時に下記のようにFeedjiraで利用するパーサーの優先順位を割りあてることによって解決することができます。

```ruby
     Feedjira.configure do |config|
       config.parsers = [
                         ...
                         Feedjira::Parser::RSS
                         Feedjira::Parser::ITunesRSS
                        ]
     end
```

   ですが、この方法ですとFeedjiraのupdateによって、パーサーが増減したときに手動で対応が必要になります。そのため、あまり望ましい解決方法ではない判断しました。




--- ここから下はこれにいたる詳細な情報です。 ---


## RSSの仕様を確認

以下を確認するとcategoryはoptionalなので、category element無いことも考慮して動作してよさそう。

 - https://validator.w3.org/feed/docs/rss2.html
 - http://cyber.harvard.edu/rss/rss.html

## Feedjiraの動作を確認

 通常のRSSパーサーであれば categories のelementsが定義されていました
 https://github.com/feedjira/feedjira/blob/master/lib/feedjira/parser/rss_entry.rb#L27

 これによりelemetが、あれば最初の値、なければnilが item.category の値となる。
 正しいパーサーが利用されれば category element が無いことが考慮さあれて値が返却されるように動作しているようです。

 ですが、このfeedは `Feedjira::Parser::ITunesRSS` が利用されているのが問題です。

```ruby
irb(main):016:0> Feedjira.parsers
  => [Feedjira::Parser::RSSFeedBurner, Feedjira::Parser::GoogleDocsAtom, Feedjira::Parser::AtomYoutube, Feedjira::Parser::AtomFeedBurner, Feedjira::Parser::Atom, Feedjira::Parser::ITunesRSS, Feedjira::Parser::RSS]
```

Feedjiraは利用するパーサーを上記の順で検証していき `Feedjira::Parser::RSS` よりも先に `Feedjira::Parser::ITunesRSS` がある。
また、このRSSは `xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"` が記載されているから `Feedjira::Parser::ITunesRSS` が利用されます。

`Feedjira::Parser::ITunesRSS` の category エレメントは少々特殊なようで...
https://github.com/feedjira/feedjira/blob/master/lib/feedjira/parser/itunes_rss.rb#L42

`_itunes_categories` となってしまっているため今回の undefined method `categories' が発生するようです。