### PR TITLE
Fix signal trap

### DIFF
--- a/lib/fastladder/crawler.rb
+++ b/lib/fastladder/crawler.rb
@@ -97,7 +97,7 @@ module Fastladder
         run_body
       rescue TimeoutError
         @logger.error "Time out: #{$!}"
-      rescue Interrupt
+      rescue SignalException
         @logger.warn "\n=> #{$!.message} trapped. Terminating..."
         return true
       rescue Exception


### PR DESCRIPTION
## 問題

SystemdでrestartをされるとSIGTERMが送られるため、
現状はExceptionを補足できずにExitCode 1で終了する。
これによりSystemdは不正終了したとみなし、restart時にプロセスを再び起動せずfaild処理になる。

## 解決方法

Interruptの親クラスであるSignalExceptionで補足することによって、
signalを送られたときもExitCode 0で終了するようにする。

これによりSystemdでrestartなどができるようになる。