### PR TITLE
Fix failed crawler at invalid chars in href attribute of links

### DIFF
--- a/lib/fastladder/crawler.rb
+++ b/lib/fastladder/crawler.rb
@@ -179,7 +179,12 @@ module Fastladder
         body
       else
         links.each do |link|
-          link['href'] = Addressable::URI.join(feed.feedlink, link['href']).normalize.to_s
+          begin
+            link['href'] = Addressable::URI.join(feed.feedlink, link['href']).normalize.to_s
+          rescue Addressable::URI::InvalidURIError
+            @logger.info "Invalid URL in link: [#{link['href']}] #{feed.feedlink}"
+            next
+          end
         end
         doc.to_html
       end


### PR DESCRIPTION
改行コードが混入されていたり、`http`が`(http`になっていたりなど、
実際の記事データにはInvalidになってしまうURLが多く存在している。

この時crawlerは`Addressable::URI::InvalidURIError`を発生させるためフィードは取得できない。

リンクをfastladderで表示する時はサニタイズがされているのを確認済。