### PR TITLE
Update nokogiri gem to 1.8.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
     multipart-post (2.0.0)
     net-http-digest_auth (1.4.1)
     net-http-persistent (2.9.4)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     ntlm-http (0.1.1)
     poltergeist (1.17.0)


### PR DESCRIPTION
libxml2 incorrectly handles certain files. An attacker can use this issue with specially constructed XML data to cause libxml2 to consume resources, leading to a denial of service.

Affected versions: Prior to 1.8.2
Fixed versions: 1.8.2
Identifier: CVE-2017-15412
Solution: Upgrade to latest version.
Sources: https://github.com/sparklemotion/nokogiri/issues/1714
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-15412