### PR TITLE
Fix show favicon

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -90,7 +90,7 @@ class ApiController < ApplicationController
         link: feed.link.html_escape,
         feedlink: feed.feedlink.html_escape,
         title: feed.title.utf8_roundtrip.html_escape,
-        icon: feed.favicon.blank? ? "/img/icon/default.png" : favicon_path(feed.id),
+        icon: feed.favicon.try(:image).try!(:blank?) ? "/img/icon/default.png" : favicon_path(feed.id),
         modified_on: modified_on ? modified_on.to_time.to_i : 0,
         subscribers_count: feed.subscribers_count,
       }
@@ -118,7 +118,7 @@ class ApiController < ApplicationController
         link: feed.link.html_escape,
         feedlink: feed.feedlink.html_escape,
         title: feed.title.utf8_roundtrip.html_escape,
-        icon: feed.favicon.blank? ? "/img/icon/default.png" : favicon_path(feed.id),
+        icon: feed.favicon.try(:image).try!(:blank?) ? "/img/icon/default.png" : favicon_path(feed.id),
         modified_on: modified_on ? modified_on.to_time.to_i : 0,
         subscribers_count: feed.subscribers_count,
       }

--- a/app/views/about/_feed.html.erb
+++ b/app/views/about/_feed.html.erb
@@ -3,7 +3,7 @@
 <div class="feedinfo">
 	<div class="feed_info">
 	<div class="channel">
-		<h3 style="background-image:url('<%= favicon_path(feed.id) %>')">
+		<h3 style="background-image:url('<%= feed.favicon.image.blank? ? "/img/icon/default.png" : favicon_path(feed.id) %>')">
 			<%= link_to feed.title, feed.link, id: "feed-title" %>
 		</h3>
 		<div class="description"><%= feed.description %></div>


### PR DESCRIPTION
FaviconがImageMagickで変換できなかった場合

` #<Favicon:0x00007fddf8bc0538 id: 8, feed_id: 8, image: nil>]`

というようにレコードだけ記録される。

現状だとこのようなfeedのアイコンはdefaultのものさえ表示されていない。
これをせめてdefaultを表示するように修正。