### PR TITLE
require 'timeout'

### DIFF
--- a/lib/fastladder/crawler.rb
+++ b/lib/fastladder/crawler.rb
@@ -1,6 +1,7 @@
 require "fastladder"
 require "tempfile"
 require "logger"
+require "timeout"
 begin
   require "image_utils"
 rescue LoadError


### PR DESCRIPTION
prevent: `rescue in run_loop': uninitialized constant Fastladder::Crawler::TimeoutError (NameError)`