### PR TITLE
URL 次第で購読確認UIがぶっ壊れるの修正

### DIFF
--- a/app/controllers/subscribe_controller.rb
+++ b/app/controllers/subscribe_controller.rb
@@ -29,7 +29,7 @@ class SubscribeController < ApplicationController
       return (redirect_to action: "index")
     end
     @feeds = feeds
-    render action: "confirm"
+    render action: "confirm", formats: [:html]
   end
 
   def subscribe

--- a/test/system/subscribe_system_test.rb
+++ b/test/system/subscribe_system_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class SubscribeSystemTest < ApplicationSystemTestCase
+  test 'can access subscribe confirm page with url that has .rss' do
+    @dankogai = Member.create!(username: 'dankogai', password: 'kogaidan', password_confirmation: 'kogaidan')
+    visit '/login'
+    fill_in 'username', with: 'dankogai'
+    fill_in 'password', with: 'kogaidan'
+    click_on 'Sign In'
+
+    assert_equal '/reader/', current_path
+
+    stub_request(:get, 'https://example.com/feed.rss?keyword=123')
+      .to_return(status: 200, body: File.read(Rails.root.join('test/fixtures/examlpe.com.feed.xml')))
+
+    visit '/subscribe/https://example.com/feed.rss?keyword=123'
+
+    assert_text 'Subscribe Feed'
+  end
+end


### PR DESCRIPTION
- Explicitly set the format to HTML for the subscription confirmation view to ensure consistent rendering across different environments.
- Introduced a new system test to verify the functionality of subscribing to an RSS feed through a URL containing `.rss`.