### PR TITLE
Switch feed_searcher gem source to GitHub repository.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'pg'
 gem 'sqlite3', '< 2.0'
 
 gem 'addressable', require: 'addressable/uri'
-gem 'feed_searcher', '>= 0.0.6'
+gem 'feed_searcher', git: 'https://github.com/fastladder/feed_searcher'
 gem 'feedjira'
 gem 'haml'
 gem 'jbuilder', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/fastladder/feed_searcher
+  revision: 9a85831bb7f82897e44bf2c39042892415e402b5
+  specs:
+    feed_searcher (0.0.6)
+      mechanize (>= 1.0.0)
+      nokogiri
+
+GIT
   remote: https://github.com/ssig33/opml
   revision: 7a9644855565401f06662f6f215cae906e5fe456
   specs:
@@ -112,9 +120,6 @@ GEM
     factory_bot_rails (6.4.3)
       factory_bot (~> 6.4)
       railties (>= 5.0.0)
-    feed_searcher (0.0.6)
-      mechanize (>= 1.0.0)
-      nokogiri
     feedjira (3.2.3)
       loofah (>= 2.3.1, < 3)
       sax-machine (>= 1.0, < 2)
@@ -160,7 +165,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
-    mechanize (2.10.0)
+    mechanize (2.10.1)
       addressable (~> 2.8)
       base64
       domain_name (~> 0.5, >= 0.5.20190701)
@@ -175,7 +180,7 @@ GEM
       webrobots (~> 0.1.2)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2024.0507)
+    mime-types-data (3.2024.0702)
     mini_magick (4.13.1)
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
@@ -276,7 +281,8 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.1)
-    rubyntlm (0.6.3)
+    rubyntlm (0.6.5)
+      base64
     rubyzip (2.3.2)
     sax-machine (1.3.2)
     selenium-webdriver (4.21.1)
@@ -323,7 +329,7 @@ DEPENDENCIES
   addressable
   capybara
   factory_bot_rails
-  feed_searcher (>= 0.0.6)
+  feed_searcher!
   feedjira
   haml
   http (~> 5.2)


### PR DESCRIPTION
- Changed the source of the 'feed_searcher' gem to a specific GitHub repository for more direct control over updates and versioning.
- Updated the Gemfile to reflect this change, ensuring the application uses the latest version from the specified repository.

これ僕ヤバというかチャンピオンクロス購読できないのが治ります