### PR TITLE
Use utf8mb4 for the example of DB config

### DIFF
--- a/config/database.yml.mysql
+++ b/config/database.yml.mysql
@@ -16,7 +16,7 @@
 #   http://dev.mysql.com/doc/refman/5.0/en/old-client.html
 development:
   adapter: mysql2
-  encoding: utf8
+  encoding: utf8mb4
   database: fastladder_development
   username: root
   password:
@@ -27,7 +27,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   adapter: mysql2
-  encoding: utf8
+  encoding: utf8mb4
   database: fastladder_test
   username: root
   password:
@@ -35,7 +35,7 @@ test:
 
 production:
   adapter: mysql2
-  encoding: utf8
+  encoding: utf8mb4
   database: fastladder_production
   username: root
   password:


### PR DESCRIPTION
これをやっておかないとfeedに絵文字などutf8mb3の範囲外の文字列が含まれていた場合にエラーが発生して該当のfeedがクロールできません。ARのmigration自体はutf8mb4でテーブルを作成しているので設定も更新したほうがいいでしょう。
Dockerfileとdocker-compose.ymlも直せたらと思ったのですがあまりいい方法が思いつきません。docker-compose.ymlはMySQL決め打ちのため、ファイルをconfig/database.ymlにmountするなどしても良いかもしれませんが。