### PR TITLE
Add a timeout for simple_fetch requests

### DIFF
--- a/lib/fastladder.rb
+++ b/lib/fastladder.rb
@@ -95,7 +95,7 @@ module Fastladder
 
   def simple_fetch(link, options = {})
     user_agent = options.fetch("User-Agent", "Fastladder (https://github.com/fastladder/fastladder)")
-    response = HTTP.follow.get(link.to_s, headers: {"User-Agent" => user_agent})
+    response = HTTP.follow.timeout(Fastladder.http_read_timeout).get(link.to_s, headers: {"User-Agent" => user_agent})
     response.to_s
   rescue Exception => e
     Rails.logger.error(e)


### PR DESCRIPTION
`fetch()` でのrequestには timeout を設定しているのですが `simple_fetch()` には設定されていませんでした。これによりCrawlerが永遠に待ち続けてしまう場合があることを確認しています。

Timeoutを追加したところ該当の問題は発生しなくなりました。

環境:
- Ubuntu 22.04 (x64)
- Ruby 3.3.4