### PR TITLE
アメブロの全記事が新着扱いになる問題の修正

### DIFF
--- a/lib/fastladder/crawler.rb
+++ b/lib/fastladder/crawler.rb
@@ -146,6 +146,7 @@ module Fastladder
 
       items = cut_off(feed, items)
       items = reject_duplicated(feed, items)
+      items = reject_stale_item_updates(feed, items)
       delete_old_items_if_new_items_are_many(feed, items)
       update_or_insert_items_to_feed(feed, items, result)
       update_unread_status(feed, result)
@@ -205,6 +206,16 @@ module Fastladder
 
     def reject_duplicated(feed, items)
       items.uniq { |item| item.guid }.reject { |item| feed.items.exists?(["guid = ? and digest = ?", item.guid, item.digest]) }
+    end
+
+    def reject_stale_item_updates(feed, items)
+      items.reject do |item|
+        next false unless item.modified_on
+        next false unless old_item = feed.items.find_by(guid: item.guid)
+        next false unless old_item.stored_on
+
+        item.modified_on.to_time <= old_item.stored_on.to_time
+      end
     end
 
     def new_items_count(feed, items)

--- a/lib/fastladder/fastladder_crawler.rb
+++ b/lib/fastladder/fastladder_crawler.rb
@@ -144,6 +144,7 @@ module Fastladder
 
       items = cut_off(feed, items)
       items = reject_duplicated(feed, items)
+      items = reject_stale_item_updates(feed, items)
       delete_old_items_if_new_items_are_many(feed, items)
       update_or_insert_items_to_feed(feed, items, result)
       update_unread_status(feed, result)
@@ -203,6 +204,16 @@ module Fastladder
 
     def reject_duplicated(feed, items)
       items.uniq { |item| item.guid }.reject { |item| feed.items.exists?(["guid = ? and digest = ?", item.guid, item.digest]) }
+    end
+
+    def reject_stale_item_updates(feed, items)
+      items.reject do |item|
+        next false unless item.modified_on
+        next false unless old_item = feed.items.find_by(guid: item.guid)
+        next false unless old_item.stored_on
+
+        item.modified_on.to_time <= old_item.stored_on.to_time
+      end
     end
 
     def new_items_count(feed, items)

--- a/test/lib/fastladder/crawler_test.rb
+++ b/test/lib/fastladder/crawler_test.rb
@@ -23,6 +23,32 @@ class Fastladder::CrawlerTest < ActiveSupport::TestCase
     assert_empty result
   end
 
+  test "reject_stale_item_updates rejects existing item when feed timestamp is older than stored_on" do
+    stored_on = Time.zone.parse("2026-07-07 12:00:00")
+    old_item = FactoryBot.create(:item, feed: @feed, guid: "same-guid", link: "http://example.com/item",
+                                        body: "old body", stored_on: stored_on, modified_on: stored_on - 1.day)
+    item = FactoryBot.build(:item, feed: @feed, guid: old_item.guid, link: old_item.link,
+                                   body: "changed body", stored_on: stored_on + 1.hour,
+                                   modified_on: stored_on - 1.second)
+
+    result = @crawler.send(:reject_stale_item_updates, @feed, [item])
+
+    assert_empty result
+  end
+
+  test "reject_stale_item_updates keeps existing item when feed timestamp is newer than stored_on" do
+    stored_on = Time.zone.parse("2026-07-07 12:00:00")
+    old_item = FactoryBot.create(:item, feed: @feed, guid: "same-guid", link: "http://example.com/item",
+                                        body: "old body", stored_on: stored_on, modified_on: stored_on - 1.day)
+    item = FactoryBot.build(:item, feed: @feed, guid: old_item.guid, link: old_item.link,
+                                   body: "changed body", stored_on: stored_on + 1.hour,
+                                   modified_on: stored_on + 1.second)
+
+    result = @crawler.send(:reject_stale_item_updates, @feed, [item])
+
+    assert_equal [item], result
+  end
+
   test "update rewrites relative links in item body" do
     atom_body = File.read(File.expand_path("../../fixtures/github.private.atom", __dir__))
     source = Struct.new(:body).new(atom_body)


### PR DESCRIPTION
数日前からアメブロの挙動が変更になり、全フィードが取得のたびにすべての記事に更新があったという判定になっています。どうも複数回curlしてみると本文などのtextが揺れる（変化がある）ようです
例: https://rssblog.ameba.jp/shibuya/rss20.xml

あわせて、今までに同じような挙動があったWordPress系のブログでも同じ原因であることを確認しました（本文にウィジェットなどで色々なものが入っており、それらが揺れる）
例: https://seikatu-goods.com/household/feed/

フィード本文が揺れることでdigestが変わり、既存記事の更新として `stored_on` が現在時刻に更新されていました。fastladderの未読判定は `stored_on >= viewed_on` に依存しているため、既読済み記事が再び新着扱いになっていました

### 修正
対策として次のようにcrawlerのロジックを変更しています

- 判定条件:
  - 同じGUIDの既存itemがある
  - 新しく取得したitemに `modified_on` がある (RSSの`pubDate`などが相当)
  - 既存itemに `stored_on` がある
  - `item.modified_on <= old_item.stored_on`
- 上記を満たす場合、そのitem更新をスキップ

### トレードオフ

`pubDate` 等を更新せずに本文だけ変更するフィードでは、その本文更新は無視されます。
本文の揺れによる再未読化を防ぐことを優先する割り切りとなります。新規GUIDの記事は従来通り取り込まれます。