### PR TITLE
Selectively ignore body-only item updates per feed or per domain

### DIFF
--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -13,6 +13,7 @@
 #  modified_on       :datetime
 #  created_on        :datetime         not null
 #  updated_on        :datetime         not null
+#  ignore_body_update :boolean         default(FALSE), not null
 #
 
 # require "fastladder/crawler"
@@ -159,6 +160,20 @@ class Feed < ActiveRecord::Base
 
   def avg_rate
     subscriptions.where("rate > ?", 0).average(:rate).to_i
+  end
+
+  # Domains listed in IGNORE_BODY_UPDATE_DOMAINS always take precedence over
+  # the per-feed ignore_body_update flag.
+  def ignore_body_update?
+    body_update_ignored_domain? || super
+  end
+
+  def body_update_ignored_domain?
+    [feedlink, link].compact.any? do |url|
+      host = Addressable::URI.parse(url).host rescue nil
+      next false unless host
+      IGNORE_BODY_UPDATE_DOMAINS.any? { |domain| host == domain || host.end_with?(".#{domain}") }
+    end
   end
 
   def except_fragment_identifier

--- a/config/initializers/feed_settings.rb
+++ b/config/initializers/feed_settings.rb
@@ -1,0 +1,9 @@
+# Feeds hosted on these domains (including their subdomains) always ignore
+# body-only item updates, regardless of the per-feed ignore_body_update flag.
+# Some providers (e.g. Ameba blogs) serve a slightly different item body on
+# every fetch, which would otherwise mark already-read items as unread again
+# on each crawl.
+IGNORE_BODY_UPDATE_DOMAINS = %w(
+  ameblo.jp
+  ameba.jp
+).freeze

--- a/db/migrate/20260723000000_add_ignore_body_update_to_feeds.rb
+++ b/db/migrate/20260723000000_add_ignore_body_update_to_feeds.rb
@@ -1,0 +1,5 @@
+class AddIgnoreBodyUpdateToFeeds < ActiveRecord::Migration[8.1]
+  def change
+    add_column :feeds, :ignore_body_update, :boolean, default: false, null: false
+  end
+end

--- a/lib/fastladder/crawler.rb
+++ b/lib/fastladder/crawler.rb
@@ -147,6 +147,7 @@ module Fastladder
       items = cut_off(feed, items)
       items = reject_duplicated(feed, items)
       items = reject_stale_item_updates(feed, items)
+      items = reject_ignored_body_updates(feed, items)
       delete_old_items_if_new_items_are_many(feed, items)
       update_or_insert_items_to_feed(feed, items, result)
       update_unread_status(feed, result)
@@ -215,6 +216,17 @@ module Fastladder
         next false unless old_item.stored_on
 
         item.modified_on.to_time <= old_item.stored_on.to_time
+      end
+    end
+
+    # Items that reach here with an existing guid already differ in digest
+    # (reject_duplicated drops unchanged ones), so an unchanged title and link
+    # means only the body changed.
+    def reject_ignored_body_updates(feed, items)
+      return items unless feed.ignore_body_update?
+      items.reject do |item|
+        next false unless old_item = feed.items.find_by(guid: item.guid)
+        old_item.title == item.title && old_item.link == item.link
       end
     end
 

--- a/lib/fastladder/fastladder_crawler.rb
+++ b/lib/fastladder/fastladder_crawler.rb
@@ -145,6 +145,7 @@ module Fastladder
       items = cut_off(feed, items)
       items = reject_duplicated(feed, items)
       items = reject_stale_item_updates(feed, items)
+      items = reject_ignored_body_updates(feed, items)
       delete_old_items_if_new_items_are_many(feed, items)
       update_or_insert_items_to_feed(feed, items, result)
       update_unread_status(feed, result)
@@ -213,6 +214,17 @@ module Fastladder
         next false unless old_item.stored_on
 
         item.modified_on.to_time <= old_item.stored_on.to_time
+      end
+    end
+
+    # Items that reach here with an existing guid already differ in digest
+    # (reject_duplicated drops unchanged ones), so an unchanged title and link
+    # means only the body changed.
+    def reject_ignored_body_updates(feed, items)
+      return items unless feed.ignore_body_update?
+      items.reject do |item|
+        next false unless old_item = feed.items.find_by(guid: item.guid)
+        old_item.title == item.title && old_item.link == item.link
       end
     end
 

--- a/test/lib/fastladder/crawler_test.rb
+++ b/test/lib/fastladder/crawler_test.rb
@@ -49,6 +49,70 @@ class Fastladder::CrawlerTest < ActiveSupport::TestCase
     assert_equal [item], result
   end
 
+  test "reject_ignored_body_updates keeps body-only updates when feed does not ignore them" do
+    old_item = FactoryBot.create(:item, feed: @feed, body: "old body")
+    item = FactoryBot.build(:item, feed: @feed, guid: old_item.guid, link: old_item.link,
+                                   title: old_item.title, body: "changed body")
+
+    result = @crawler.send(:reject_ignored_body_updates, @feed, [item])
+
+    assert_equal [item], result
+  end
+
+  test "reject_ignored_body_updates rejects body-only updates when feed ignores them" do
+    @feed.update!(ignore_body_update: true)
+    old_item = FactoryBot.create(:item, feed: @feed, body: "old body")
+    item = FactoryBot.build(:item, feed: @feed, guid: old_item.guid, link: old_item.link,
+                                   title: old_item.title, body: "changed body")
+
+    result = @crawler.send(:reject_ignored_body_updates, @feed, [item])
+
+    assert_empty result
+  end
+
+  test "reject_ignored_body_updates keeps updates that also change the title" do
+    @feed.update!(ignore_body_update: true)
+    old_item = FactoryBot.create(:item, feed: @feed, body: "old body")
+    item = FactoryBot.build(:item, feed: @feed, guid: old_item.guid, link: old_item.link,
+                                   title: "changed title", body: "changed body")
+
+    result = @crawler.send(:reject_ignored_body_updates, @feed, [item])
+
+    assert_equal [item], result
+  end
+
+  test "reject_ignored_body_updates keeps updates that also change the link" do
+    @feed.update!(ignore_body_update: true)
+    old_item = FactoryBot.create(:item, feed: @feed, body: "old body")
+    item = FactoryBot.build(:item, feed: @feed, guid: old_item.guid, link: "http://example.com/moved",
+                                   title: old_item.title, body: "changed body")
+
+    result = @crawler.send(:reject_ignored_body_updates, @feed, [item])
+
+    assert_equal [item], result
+  end
+
+  test "reject_ignored_body_updates keeps new items" do
+    @feed.update!(ignore_body_update: true)
+    item = FactoryBot.build(:item, feed: @feed, guid: "brand-new-guid")
+
+    result = @crawler.send(:reject_ignored_body_updates, @feed, [item])
+
+    assert_equal [item], result
+  end
+
+  test "reject_ignored_body_updates rejects body-only updates for feeds on listed domains" do
+    feed = FactoryBot.create(:feed, feedlink: "http://rssblog.ameba.jp/someone/rss20.xml",
+                                    link: "http://ameblo.jp/someone/")
+    old_item = FactoryBot.create(:item, feed: feed, body: "old body")
+    item = FactoryBot.build(:item, feed: feed, guid: old_item.guid, link: old_item.link,
+                                   title: old_item.title, body: "changed body")
+
+    result = @crawler.send(:reject_ignored_body_updates, feed, [item])
+
+    assert_empty result
+  end
+
   test "update rewrites relative links in item body" do
     atom_body = File.read(File.expand_path("../../fixtures/github.private.atom", __dir__))
     source = Struct.new(:body).new(atom_body)

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -156,4 +156,29 @@ class FeedTest < ActiveSupport::TestCase
     feed = FactoryBot.create(:feed_without_title)
     refute_nil feed.title
   end
+
+  test "ignore_body_update? is false by default" do
+    feed = FactoryBot.create(:feed)
+    refute feed.ignore_body_update?
+  end
+
+  test "ignore_body_update? respects the per-feed flag" do
+    feed = FactoryBot.create(:feed, ignore_body_update: true)
+    assert feed.ignore_body_update?
+  end
+
+  test "ignore_body_update? is true when the feed link is on a listed domain" do
+    feed = FactoryBot.create(:feed, link: "http://ameblo.jp/someone/")
+    assert feed.ignore_body_update?
+  end
+
+  test "ignore_body_update? is true when the feedlink is on a subdomain of a listed domain" do
+    feed = FactoryBot.create(:feed, feedlink: "http://rssblog.ameba.jp/someone/rss20.xml")
+    assert feed.ignore_body_update?
+  end
+
+  test "ignore_body_update? is false for hosts that merely end with a listed domain" do
+    feed = FactoryBot.create(:feed, feedlink: "http://notameba.jp/rss", link: "http://notameblo.jp/")
+    refute feed.ignore_body_update?
+  end
 end


### PR DESCRIPTION
## Summary

Some feed providers (most notably Ameba blogs) serve a slightly different item body on every fetch — e.g. rotating ad markup or tracking parameters embedded in the content. Since the item digest is computed from the title and body, every crawl changes the digest of existing items and marks already-read items as unread again.

This PR adds an opt-in mechanism to ignore such body-only item updates, per feed or per domain:

- A new `feeds.ignore_body_update` boolean column (default `false`) lets individual feeds opt in to ignoring body-only updates.
- `config/initializers/feed_settings.rb` defines `IGNORE_BODY_UPDATE_DOMAINS`, a list of domains (subdomains included) whose feeds always ignore body-only updates. This list takes precedence over the per-feed flag and ships with the Ameba blog domains (`ameblo.jp`, `ameba.jp`) by default.
- The crawler drops an incoming item only when the feed ignores body updates, an item with the same guid already exists, and the title and link are unchanged — i.e. only the body changed. Updates that also change the title or link are applied as usual. Feeds that do not opt in behave exactly as before.

## Changes

- Migration adding `ignore_body_update` (boolean, default `false`, not null) to `feeds`
- `Feed#ignore_body_update?` combining the domain list and the per-feed flag
- `config/initializers/feed_settings.rb` with `IGNORE_BODY_UPDATE_DOMAINS`
- `reject_ignored_body_updates` filter added to both crawler implementations
- Tests for the new model method and crawler filtering

## Test plan

- `bin/rails test` — 246 runs, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
