### PR TITLE
Add ignore_body_update toggle to the feed about page

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -1,4 +1,6 @@
 class AboutController < ApplicationController
+  before_action :login_required, only: :update
+
   def index
     url = url_from_path(:url) unless params[:url].blank?
     @feed = Feed.find_by(feedlink: url) unless url.blank?
@@ -14,6 +16,17 @@ class AboutController < ApplicationController
         format.json { render json: @feed.to_json } # for backward compatibility
         format.any { head :not_found }
       end
+    end
+  end
+
+  def update
+    url = url_from_path(:url) unless params[:url].blank?
+    feed = Feed.find_by(feedlink: url) unless url.blank?
+    if feed
+      feed.update!(ignore_body_update: params[:ignore_body_update].present?)
+      redirect_to about_path(url: feed.feedlink)
+    else
+      render file: "#{Rails.root}/public/404.html", status: :not_found
     end
   end
 end

--- a/app/views/about/_feed.html.erb
+++ b/app/views/about/_feed.html.erb
@@ -22,6 +22,20 @@
 		</li>
 		<li class="subscribers_count"><%= users(feed.subscribers_count) %></li>
 		<li class="avg_rate">rate average <%= rate_image(avg_rate) %> <span id="avg-rate"><%= avg_rate %></span></li>
+		<% if logged_in? -%>
+		<li class="ignore_body_update">
+			<% if feed.body_update_ignored_domain? -%>
+			<input type="checkbox" checked disabled>
+			ignore body-only item updates <span class="note">(always on for this domain)</span>
+			<% else -%>
+			<%= form_tag(about_path(url: feed.feedlink), style: "display:inline") do %>
+				<%= check_box_tag :ignore_body_update, 1, feed.ignore_body_update %>
+				<%= label_tag :ignore_body_update, "ignore body-only item updates" %>
+				<input type="submit" value="Save">
+			<% end %>
+			<% end -%>
+		</li>
+		<% end -%>
 	</ul>
 	</div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
 
   namespace :about do
     get '*url', action: :index, format: false
+    post '*url', action: :update, format: false, as: nil
   end
 
   namespace :user do

--- a/test/controllers/about_controller_test.rb
+++ b/test/controllers/about_controller_test.rb
@@ -19,4 +19,35 @@ class AboutControllerTest < ActionController::TestCase
     get :index, params: { url: "http://example.com/unknown" }
     assert_equal 404, response.status
   end
+
+  test "GET index shows ignore_body_update form when logged in" do
+    member = FactoryBot.create(:member, password: "mala", password_confirmation: "mala")
+    feed = FactoryBot.create(:feed)
+    favicon = Favicon.create(feed: feed, image: "dummy")
+    feed.update(favicon: favicon)
+
+    get :index, params: { url: feed.feedlink }, session: { member_id: member.id }
+    assert_response :success
+    assert_select "input#ignore_body_update[type=checkbox]"
+  end
+
+  test "POST update sets ignore_body_update" do
+    member = FactoryBot.create(:member, password: "mala", password_confirmation: "mala")
+    feed = FactoryBot.create(:feed)
+
+    post :update, params: { url: feed.feedlink, ignore_body_update: "1" }, session: { member_id: member.id }
+    assert_redirected_to about_path(url: feed.feedlink)
+    assert feed.reload.ignore_body_update
+
+    post :update, params: { url: feed.feedlink }, session: { member_id: member.id }
+    assert_not feed.reload.ignore_body_update
+  end
+
+  test "POST update requires login" do
+    feed = FactoryBot.create(:feed)
+
+    post :update, params: { url: feed.feedlink, ignore_body_update: "1" }
+    assert_redirected_to login_path
+    assert_not feed.reload.ignore_body_update
+  end
 end

--- a/test/routing/about_routing_test.rb
+++ b/test/routing/about_routing_test.rb
@@ -7,4 +7,11 @@ class AboutRoutingTest < ActionDispatch::IntegrationTest
       { controller: "about", action: "index", url: "http://example.com/index.xml" }
     )
   end
+
+  test "routes about#update" do
+    assert_routing(
+      { method: "post", path: "/about/http://example.com/index.xml" },
+      { controller: "about", action: "update", url: "http://example.com/index.xml" }
+    )
+  end
 end


### PR DESCRIPTION
## Summary

Follow-up to #565, which introduced the `feeds.ignore_body_update` flag but offered no way to change it from the UI.

This PR adds a toggle for `ignore_body_update` to the feed detail page (`/about/:url_of_feed`):

- `AboutController#update` (POST `/about/*url`, login required) accepts an `ignore_body_update` parameter and updates the feed, then redirects back to the about page. Unknown feed URLs return 404 as in `index`.
- The feed info partial shows a checkbox with a Save button for logged-in users, styled like the rest of the feed info list.
- For feeds on domains listed in `IGNORE_BODY_UPDATE_DOMAINS` (where the setting is forced on), the checkbox is shown checked and disabled with a note instead of the form.

## Changes

- `config/routes.rb`: POST route in the `about` namespace
- `app/controllers/about_controller.rb`: `update` action with `login_required`
- `app/views/about/_feed.html.erb`: toggle UI
- Tests: controller tests for the toggle, login requirement, and checkbox rendering; routing test for the new route

## Test plan

- `bin/rails test` — 250 runs, 0 failures