### PR TITLE
Fix SQL injection in RpcController#check_digest

### DIFF
--- a/app/controllers/rpc_controller.rb
+++ b/app/controllers/rpc_controller.rb
@@ -12,7 +12,7 @@ class RpcController < ApplicationController
 
   def check_digest
     digests = JSON.parse(params[:digests]).uniq.sort
-    render json: (digests - Item.where(digests).map{|x| x.digest}.uniq.sort)
+    render json: (digests - Item.where(digest: digests).map{|x| x.digest}.uniq.sort)
   end
 
   # TODO Fix Baaaaaad SQL

--- a/test/controllers/rpc_controller_test.rb
+++ b/test/controllers/rpc_controller_test.rb
@@ -1,7 +1,32 @@
 require "test_helper"
 
 class RpcControllerTest < ActionController::TestCase
+  def setup
+    @member = FactoryBot.create(:member, password: "mala", password_confirmation: "mala")
+    @member.set_auth_key
+    @member.save!
+    @feed = FactoryBot.create(:feed)
+    @item = FactoryBot.create(:item, feed: @feed)
+  end
+
   test "controller exists" do
     assert RpcController
+  end
+
+  test "POST check_digest returns only unknown digests" do
+    unknown = Digest::SHA1.hexdigest("unknown")
+
+    post :check_digest, params: { api_key: @member.auth_key, digests: [@item.digest, unknown].to_json }
+
+    assert_equal [unknown], JSON.parse(response.body)
+  end
+
+  test "POST check_digest treats digests as values, not SQL" do
+    payload = "' OR 1=1 --"
+
+    post :check_digest, params: { api_key: @member.auth_key, digests: [payload].to_json }
+
+    assert_response :success
+    assert_equal [payload], JSON.parse(response.body)
   end
 end


### PR DESCRIPTION
Fixes #573.

`RpcController#check_digest` passed the JSON-decoded, attacker-controlled `digests` array straight to `Item.where(digests)`. Active Record treats an array condition as a raw SQL fragment (first element is the SQL template), so any authenticated user — anyone able to get an API key at `/account/apikey` — could inject arbitrary SQL into the `WHERE` clause:

```
JSON.parse('["1=1) OR (1=1"]')
# => SELECT "items".* FROM "items" WHERE (1=1) OR (1=1)
```

## Changes

- Use the hash condition `Item.where(digest: digests)` so the digests are bound as values.
- Add controller tests for `check_digest`: one covering the normal case (only unknown digests are returned) and one asserting that a SQL payload is treated as a plain value. Both fail against the old implementation.

Note that the old code was also broken for legitimate input: a real SHA1 digest such as `356a192b...` produced `WHERE (356a192b...)`, which raises `SQLite3::SQLException: unrecognized token`. The hash condition fixes that as well.

Full test suite passes (252 runs, 515 assertions, 0 failures, 0 errors).