### PR TITLE
Sanitize item body in mobile reader

### DIFF
--- a/app/helpers/mobile_helper.rb
+++ b/app/helpers/mobile_helper.rb
@@ -1,5 +1,0 @@
-module MobileHelper
-  def remove_style_attr_of_all_tags(html)
-    html && html.gsub(/<[^>]+>/) { |tag| tag.gsub(/style="[^"]+"/, '') }
-  end
-end

--- a/app/views/mobile/read_feed.html.haml
+++ b/app/views/mobile/read_feed.html.haml
@@ -11,7 +11,7 @@
     %h3 
       %a.read{href: item.link, target: "_blank"}=item.title
 
-    %div!= remove_style_attr_of_all_tags(item.body)
+    %div= item.body.to_s.scrub_html
     %div
       %p.smallgrey 
         %a.pin{href: "/mobile/#{item.id}/pin"} Pin

--- a/test/controllers/mobile_controller_test.rb
+++ b/test/controllers/mobile_controller_test.rb
@@ -1,7 +1,24 @@
 require "test_helper"
 
-class MobileControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+class MobileControllerTest < ActionController::TestCase
+  def setup
+    @member = FactoryBot.create(:member, password: "mala", password_confirmation: "mala")
+  end
+
+  test "GET read_feed sanitizes item body" do
+    item = FactoryBot.create(:item,
+                             body: '<script>alert(1)</script><img src="x" onerror="alert(2)"><b style="color:red">hello</b>',
+                             stored_on: 1.hour.ago)
+    feed = FactoryBot.create(:feed, items: [ item ])
+    subscription = @member.subscriptions.create!(feed: feed, has_unread: true, viewed_on: 2.hours.ago)
+
+    get :read_feed, params: { feed_id: subscription.id }, session: { member_id: @member.id }
+
+    assert_response :success
+    rendered_body = css_select("#item-#{item.id} > div").first.inner_html
+    assert_no_match(/<script/, rendered_body)
+    assert_no_match(/onerror/, rendered_body)
+    assert_no_match(/style=/, rendered_body)
+    assert_match(/<b>hello<\/b>/, rendered_body)
+  end
 end


### PR DESCRIPTION
Fixes #574.

`app/views/mobile/read_feed.html.haml` rendered `item.body` with `!=` (unescaped) after passing it through `remove_style_attr_of_all_tags`, which only stripped `style` attributes. Feed content is stored by the crawler without sanitization, so a malicious feed publisher could execute arbitrary JavaScript in a subscriber's browser (`<script>`, `<img onerror>`, ...) when the feed was opened in `/mobile`.

## Changes

- Render the item body through `String#scrub_html`, the same allow-list sanitizer the desktop reader uses via `Item#as_json`. Since `scrub_html` returns an html-safe buffer, `=` is used instead of `!=`.
- Remove `MobileHelper#remove_style_attr_of_all_tags`, which is now unused (`style` is not in `Settings.allow_attributes`, so `scrub_html` already drops it).
- Add a regression test in `test/controllers/mobile_controller_test.rb` asserting that `<script>`, event handler attributes and `style` attributes are stripped while safe markup is preserved.

## Verification

The new test fails on `master` (the raw payload is rendered verbatim) and passes with this change. Full suite: 253 runs, 524 assertions, 0 failures, 0 errors.