### PR TITLE
Reject private and internal addresses when fetching feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,28 @@ $ foreman start         # run web and crawler processes
 $ foreman start web     # run web process
 $ foreman start crawler # run crawler process
 ```
+
+## Configuration
+
+### `ALLOW_INTRANET_FEEDS`
+
+Fastladder fetches every feed URL its users ask for, so by default it refuses to
+request URLs that resolve to a private, loopback, link-local or otherwise
+non-globally-routable address. This keeps a user from pointing fastladder at
+hosts that are only reachable from the machine it runs on, such as a cloud
+metadata endpoint or an internal admin panel.
+
+Set `ALLOW_INTRANET_FEEDS` to a truthy value (`1`, `true`, `yes` or `on`,
+case-insensitive) to lift that restriction and let fastladder subscribe to feeds
+served inside your own network:
+
+```
+$ ALLOW_INTRANET_FEEDS=1 bundle exec rails server
+$ ALLOW_INTRANET_FEEDS=1 bundle exec ruby script/crawler
+```
+
+The default is off. Turn it on only when your installation is limited to trusted
+users, because any of them can then make fastladder issue requests to any host
+your server can reach. Only `http` and `https` URLs are accepted either way.
+Set it for both the web and the crawler process, since each of them fetches
+feeds on its own.

--- a/app/controllers/api/feed_controller.rb
+++ b/app/controllers/api/feed_controller.rb
@@ -11,6 +11,7 @@ class Api::FeedController < ApplicationController
   def discover
     feeds = []
     url = Addressable::URI.parse(params[:url])
+    return render json: [].to_json unless Fastladder::UrlValidator.safe?(url.normalize)
     FeedSearcher.search(url.normalize.to_s).each do |feedlink|
       feedlink = (url + feedlink).to_s
       if feed = Feed.find_by(feedlink: feedlink)

--- a/app/controllers/subscribe_controller.rb
+++ b/app/controllers/subscribe_controller.rb
@@ -12,6 +12,10 @@ class SubscribeController < ApplicationController
     feeds = []
     # params[:url] is http:/example.com because of squeeze("/")
     @url = url_from_path(:url)
+    unless Fastladder::UrlValidator.safe?(@url)
+      flash[:notice] = "please check URL"
+      return (redirect_to action: "index")
+    end
     FeedSearcher.search(@url).each do |feedlink|
       if feed = Feed.find_by(feedlink: feedlink)
         if sub = current_member.subscribed(feed)

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -109,8 +109,7 @@ class Feed < ActiveRecord::Base
   def fetch_favicon!
     self.favicon ||= Favicon.new(feed: self)
     favicon_list.each do |uri|
-      next unless Fastladder::UrlValidator.safe?(uri)
-      next unless response = URI.open(uri.to_s) rescue nil # ensure timeout
+      next unless response = open_favicon(uri)
       next if response.status.last.to_i >= 400
       # MiniMagick will determine the image type from extension of file name
       ext = response.meta["content-type"] == 'image/vnd.microsoft.icon' ? ".ico" : File.basename(uri.to_s)
@@ -136,6 +135,25 @@ class Feed < ActiveRecord::Base
         tmp.close!
       end
     end
+  end
+
+  # open-uri follows redirects by itself and would happily land on an internal
+  # address, so redirects are turned off and followed here, validating every hop.
+  def open_favicon(uri)
+    url = uri.to_s
+    Fastladder::REDIRECT_LIMIT.times do
+      return nil unless Fastladder::UrlValidator.safe?(url)
+      begin
+        return URI.open(url, redirect: false) # ensure timeout
+      rescue OpenURI::HTTPRedirect => e
+        target = e.uri.to_s
+        return nil unless Fastladder::UrlValidator.safe_redirect?(url, target)
+        url = target
+      rescue StandardError
+        return nil
+      end
+    end
+    nil
   end
 
   def favicon_list

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -109,6 +109,7 @@ class Feed < ActiveRecord::Base
   def fetch_favicon!
     self.favicon ||= Favicon.new(feed: self)
     favicon_list.each do |uri|
+      next unless Fastladder::UrlValidator.safe?(uri)
       next unless response = URI.open(uri.to_s) rescue nil # ensure timeout
       next if response.status.last.to_i >= 400
       # MiniMagick will determine the image type from extension of file name

--- a/lib/fastladder.rb
+++ b/lib/fastladder.rb
@@ -3,10 +3,12 @@ require 'openssl'
 require 'open-uri'
 require 'net/http'
 require 'singleton'
+require_relative 'fastladder/url_validator'
 
 module Fastladder
   Version = '0.0.3'
   HTTP_ACCEPT = 'text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5'
+  REDIRECT_LIMIT = 5
 
   module ClassMethods
     attr_reader :http_proxy, :http_proxy_except_hosts, :crawler_user_agent
@@ -68,6 +70,7 @@ module Fastladder
 
   def fetch(link, options = {})
     uri = link.kind_of?(URI) ? link : URI.parse(link)
+    UrlValidator.validate!(uri)
 
     http_class = Net::HTTP
     # if proxy = uri.find_proxy || Fastladder.http_proxy
@@ -103,8 +106,22 @@ module Fastladder
 
   def simple_fetch(link, options = {})
     user_agent = options.fetch("User-Agent", "Fastladder (https://github.com/fastladder/fastladder)")
-    response = HTTP.follow.timeout(connect: Fastladder.http_open_timeout, read: Fastladder.http_read_timeout).get(link.to_s, headers: {"User-Agent" => user_agent})
-    response.to_s
+    client = HTTP.timeout(connect: Fastladder.http_open_timeout, read: Fastladder.http_read_timeout)
+    url = link.to_s
+    REDIRECT_LIMIT.times do
+      UrlValidator.validate!(url)
+      response = client.get(url, headers: {"User-Agent" => user_agent})
+      return response.to_s unless response.status.redirect?
+      location = response.headers["Location"]
+      response.flush
+      raise UrlValidator::UnsafeUrlError, "redirect without location: #{url}" if location.blank?
+      target = URI.join(url, location).to_s
+      unless UrlValidator.safe_redirect?(url, target)
+        raise UrlValidator::UnsafeUrlError, "unsafe redirect: #{url} => #{target}"
+      end
+      url = target
+    end
+    raise "too many redirects: #{link}"
   rescue Exception => e
     Rails.logger.error(e)
     Rails.logger.error(e.backtrace.join("\n"))

--- a/lib/fastladder/crawler.rb
+++ b/lib/fastladder/crawler.rb
@@ -54,6 +54,10 @@ module Fastladder
         begin
           @logger.info "fetch: #{feed.feedlink}"
           response = Fastladder.fetch(feed.feedlink, modified_on: feed.modified_on)
+        rescue Fastladder::UrlValidator::UnsafeUrlError => e
+          result[:message] = "Error: #{e.message}"
+          result[:error] = true
+          break
         end
         @logger.info "HTTP status: [#{response.code}] #{feed.feedlink}"
         case response
@@ -80,7 +84,13 @@ module Fastladder
         #   break
         when Net::HTTPRedirection
           @logger.info "Redirect: #{feed.feedlink} => #{response["location"]}"
-          feed.feedlink = URI.join(feed.feedlink, response["location"])
+          target = redirect_target(feed.feedlink, response["location"])
+          unless target
+            result[:message] = "Error: unsafe redirect to #{response["location"]}"
+            result[:error] = true
+            break
+          end
+          feed.feedlink = target
           feed.modified_on = nil
           feed.save
         else
@@ -90,11 +100,20 @@ module Fastladder
           break
         end
       end
-      result[:response_code] = response.code.to_i
+      result[:response_code] = response.code.to_i if response
       result
     end
 
     private
+
+    def redirect_target(feedlink, location)
+      return nil if location.blank?
+      target = URI.join(feedlink, location).to_s
+      return nil unless Fastladder::UrlValidator.safe_redirect?(feedlink, target)
+      target
+    rescue URI::InvalidURIError
+      nil
+    end
 
     def run_loop
       begin

--- a/lib/fastladder/url_validator.rb
+++ b/lib/fastladder/url_validator.rb
@@ -1,0 +1,73 @@
+require "ipaddr"
+require "socket"
+require "uri"
+
+module Fastladder
+  # Feed URLs come from users, so every URL fastladder fetches has to be checked
+  # before the request is made: only plain http(s) URLs resolving to a globally
+  # routable address are allowed.
+  module UrlValidator
+    class UnsafeUrlError < StandardError; end
+
+    ALLOWED_SCHEMES = %w(http https).freeze
+
+    BLOCKED_RANGES = %w(
+      0.0.0.0/8
+      10.0.0.0/8
+      100.64.0.0/10
+      127.0.0.0/8
+      169.254.0.0/16
+      172.16.0.0/12
+      192.0.0.0/24
+      192.168.0.0/16
+      198.18.0.0/15
+      224.0.0.0/4
+      240.0.0.0/4
+      ::/128
+      ::1/128
+      64:ff9b::/96
+      fc00::/7
+      fe80::/10
+      ff00::/8
+    ).map { |range| IPAddr.new(range) }.freeze
+
+    module_function
+
+    def safe?(url)
+      uri = URI.parse(url.to_s)
+      return false unless ALLOWED_SCHEMES.include?(uri.scheme)
+      return false if uri.host.blank?
+      resolve(uri.host).none? { |address| blocked?(address) }
+    rescue URI::InvalidURIError
+      false
+    end
+
+    def validate!(url)
+      raise UnsafeUrlError, "unsafe URL: #{url}" unless safe?(url)
+      url
+    end
+
+    # A redirect must not downgrade https to http, and its destination has to be
+    # safe on its own.
+    def safe_redirect?(from, to)
+      return false if URI.parse(from.to_s).scheme == "https" && URI.parse(to.to_s).scheme != "https"
+      safe?(to)
+    rescue URI::InvalidURIError
+      false
+    end
+
+    # Names that do not resolve are left to the HTTP layer: it cannot connect to
+    # them either.
+    def resolve(host)
+      host = host.delete_prefix("[").delete_suffix("]")
+      Addrinfo.getaddrinfo(host, nil, nil, :STREAM).map { |info| IPAddr.new(info.ip_address) }
+    rescue SocketError, IPAddr::InvalidAddressError
+      []
+    end
+
+    def blocked?(address)
+      address = address.native if address.ipv4_mapped?
+      BLOCKED_RANGES.any? { |range| range.include?(address) }
+    end
+  end
+end

--- a/lib/fastladder/url_validator.rb
+++ b/lib/fastladder/url_validator.rb
@@ -6,10 +6,18 @@ module Fastladder
   # Feed URLs come from users, so every URL fastladder fetches has to be checked
   # before the request is made: only plain http(s) URLs resolving to a globally
   # routable address are allowed.
+  #
+  # An installation that only serves trusted users may need to subscribe to feeds
+  # hosted on its own network. Setting ALLOW_INTRANET_FEEDS to a truthy value
+  # lifts the address restriction; the scheme restriction always applies.
   module UrlValidator
     class UnsafeUrlError < StandardError; end
 
     ALLOWED_SCHEMES = %w(http https).freeze
+
+    INTRANET_ENV_KEY = "ALLOW_INTRANET_FEEDS".freeze
+
+    TRUTHY_VALUES = %w(1 true yes on).freeze
 
     BLOCKED_RANGES = %w(
       0.0.0.0/8
@@ -65,7 +73,12 @@ module Fastladder
       []
     end
 
+    def intranet_feeds_allowed?
+      TRUTHY_VALUES.include?(ENV[INTRANET_ENV_KEY].to_s.strip.downcase)
+    end
+
     def blocked?(address)
+      return false if intranet_feeds_allowed?
       address = address.native if address.ipv4_mapped?
       BLOCKED_RANGES.any? { |range| range.include?(address) }
     end

--- a/test/lib/fastladder/crawler_test.rb
+++ b/test/lib/fastladder/crawler_test.rb
@@ -129,6 +129,40 @@ class Fastladder::CrawlerTest < ActiveSupport::TestCase
     assert_equal 1, doc.css('a[href="http://example.com/bundler/bundler/tree/1-9-stable"]').size
   end
 
+  test "crawl does not store a redirect to a private address" do
+    @feed.update!(feedlink: "http://example.com/feed.xml")
+    response = Net::HTTPMovedPermanently.new("1.1", "301", "Moved Permanently")
+    response["location"] = "http://169.254.169.254/latest/meta-data/"
+
+    result = Fastladder.stub :fetch, response do
+      @crawler.crawl(@feed)
+    end
+
+    assert result[:error]
+    assert_equal "http://example.com/feed.xml", @feed.reload.feedlink
+  end
+
+  test "crawl stores a redirect to a public address" do
+    @feed.update!(feedlink: "http://example.com/feed.xml")
+    response = Net::HTTPMovedPermanently.new("1.1", "301", "Moved Permanently")
+    response["location"] = "/moved.xml"
+
+    Fastladder.stub :fetch, response do
+      @crawler.crawl(@feed)
+    end
+
+    assert_equal "http://example.com/moved.xml", @feed.reload.feedlink
+  end
+
+  test "crawl reports an error when the feedlink is unsafe" do
+    @feed.update!(feedlink: "http://127.0.0.1/feed.xml")
+
+    result = @crawler.crawl(@feed)
+
+    assert result[:error]
+    assert_nil result[:response_code]
+  end
+
   test "cut_off limits items when too large feed" do
     items = FactoryBot.build_list(:item, Fastladder::Crawler::ITEMS_LIMIT + 1)
     @feed.items << items

--- a/test/lib/fastladder/url_validator_test.rb
+++ b/test/lib/fastladder/url_validator_test.rb
@@ -51,4 +51,57 @@ class Fastladder::UrlValidatorTest < ActiveSupport::TestCase
   test "safe_redirect? rejects an unsafe destination" do
     refute Fastladder::UrlValidator.safe_redirect?("http://example.com/", "http://127.0.0.1/")
   end
+
+  test "ALLOW_INTRANET_FEEDS is off unless it is set to a truthy value" do
+    refute Fastladder::UrlValidator.intranet_feeds_allowed?
+
+    %w(1 true TRUE yes on).each do |value|
+      with_intranet_feeds(value) { assert Fastladder::UrlValidator.intranet_feeds_allowed?, value }
+    end
+
+    %w(0 false no off).each do |value|
+      with_intranet_feeds(value) { refute Fastladder::UrlValidator.intranet_feeds_allowed?, value }
+    end
+  end
+
+  test "allows private and loopback addresses when ALLOW_INTRANET_FEEDS is set" do
+    with_intranet_feeds("1") do
+      assert Fastladder::UrlValidator.safe?("http://127.0.0.1/")
+      assert Fastladder::UrlValidator.safe?("http://[::1]/")
+      assert Fastladder::UrlValidator.safe?("http://10.0.0.1/")
+      assert Fastladder::UrlValidator.safe?("http://192.168.0.1/feed.xml")
+      assert Fastladder::UrlValidator.safe?("http://169.254.169.254/")
+      assert Fastladder::UrlValidator.safe?("http://example.com/feed.xml")
+    end
+  end
+
+  test "keeps rejecting other schemes when ALLOW_INTRANET_FEEDS is set" do
+    with_intranet_feeds("1") do
+      refute Fastladder::UrlValidator.safe?("file:///etc/passwd")
+      refute Fastladder::UrlValidator.safe?("ftp://example.com/feed.xml")
+    end
+  end
+
+  test "validate! accepts an intranet url when ALLOW_INTRANET_FEEDS is set" do
+    with_intranet_feeds("yes") do
+      assert_equal "http://192.168.0.1/feed.xml", Fastladder::UrlValidator.validate!("http://192.168.0.1/feed.xml")
+    end
+  end
+
+  test "safe_redirect? follows a redirect to an intranet host when ALLOW_INTRANET_FEEDS is set" do
+    with_intranet_feeds("true") do
+      assert Fastladder::UrlValidator.safe_redirect?("http://example.com/", "http://192.168.0.1/feed.xml")
+      refute Fastladder::UrlValidator.safe_redirect?("https://example.com/", "http://192.168.0.1/feed.xml")
+    end
+  end
+
+  private
+
+  def with_intranet_feeds(value)
+    previous = ENV[Fastladder::UrlValidator::INTRANET_ENV_KEY]
+    ENV[Fastladder::UrlValidator::INTRANET_ENV_KEY] = value
+    yield
+  ensure
+    ENV[Fastladder::UrlValidator::INTRANET_ENV_KEY] = previous
+  end
 end

--- a/test/lib/fastladder/url_validator_test.rb
+++ b/test/lib/fastladder/url_validator_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class Fastladder::UrlValidatorTest < ActiveSupport::TestCase
+  test "allows a public http url" do
+    assert Fastladder::UrlValidator.safe?("http://example.com/feed.xml")
+  end
+
+  test "rejects schemes other than http and https" do
+    refute Fastladder::UrlValidator.safe?("file:///etc/passwd")
+    refute Fastladder::UrlValidator.safe?("ftp://example.com/feed.xml")
+    refute Fastladder::UrlValidator.safe?("/feed.xml")
+  end
+
+  test "rejects loopback addresses" do
+    refute Fastladder::UrlValidator.safe?("http://127.0.0.1/")
+    refute Fastladder::UrlValidator.safe?("http://[::1]/")
+    refute Fastladder::UrlValidator.safe?("http://localhost/")
+  end
+
+  test "rejects private and link local addresses" do
+    refute Fastladder::UrlValidator.safe?("http://10.0.0.1/")
+    refute Fastladder::UrlValidator.safe?("http://172.16.0.1/")
+    refute Fastladder::UrlValidator.safe?("http://192.168.0.1/")
+    refute Fastladder::UrlValidator.safe?("http://169.254.169.254/latest/meta-data/")
+  end
+
+  test "rejects addresses written in an alternative notation" do
+    refute Fastladder::UrlValidator.safe?("http://2130706433/")
+    refute Fastladder::UrlValidator.safe?("http://0177.0.0.1/")
+    refute Fastladder::UrlValidator.safe?("http://[::ffff:127.0.0.1]/")
+  end
+
+  test "rejects a host name resolving to a private address" do
+    Fastladder::UrlValidator.stub :resolve, [IPAddr.new("127.0.0.1")] do
+      refute Fastladder::UrlValidator.safe?("http://feed.example.com/")
+    end
+  end
+
+  test "validate! raises for an unsafe url" do
+    assert_raises Fastladder::UrlValidator::UnsafeUrlError do
+      Fastladder::UrlValidator.validate!("http://169.254.169.254/")
+    end
+  end
+
+  test "safe_redirect? rejects a downgrade from https to http" do
+    refute Fastladder::UrlValidator.safe_redirect?("https://example.com/", "http://example.com/")
+    assert Fastladder::UrlValidator.safe_redirect?("http://example.com/", "https://example.com/")
+    assert Fastladder::UrlValidator.safe_redirect?("https://example.com/", "https://example.org/")
+  end
+
+  test "safe_redirect? rejects an unsafe destination" do
+    refute Fastladder::UrlValidator.safe_redirect?("http://example.com/", "http://127.0.0.1/")
+  end
+end

--- a/test/lib/fastladder/url_validator_test.rb
+++ b/test/lib/fastladder/url_validator_test.rb
@@ -1,8 +1,12 @@
 require "test_helper"
 
 class Fastladder::UrlValidatorTest < ActiveSupport::TestCase
+  PUBLIC_ADDRESS = "203.0.113.1".freeze
+
   test "allows a public http url" do
-    assert Fastladder::UrlValidator.safe?("http://example.com/feed.xml")
+    with_public_dns do
+      assert Fastladder::UrlValidator.safe?("http://example.com/feed.xml")
+    end
   end
 
   test "rejects schemes other than http and https" do
@@ -43,9 +47,11 @@ class Fastladder::UrlValidatorTest < ActiveSupport::TestCase
   end
 
   test "safe_redirect? rejects a downgrade from https to http" do
-    refute Fastladder::UrlValidator.safe_redirect?("https://example.com/", "http://example.com/")
-    assert Fastladder::UrlValidator.safe_redirect?("http://example.com/", "https://example.com/")
-    assert Fastladder::UrlValidator.safe_redirect?("https://example.com/", "https://example.org/")
+    with_public_dns do
+      refute Fastladder::UrlValidator.safe_redirect?("https://example.com/", "http://example.com/")
+      assert Fastladder::UrlValidator.safe_redirect?("http://example.com/", "https://example.com/")
+      assert Fastladder::UrlValidator.safe_redirect?("https://example.com/", "https://example.org/")
+    end
   end
 
   test "safe_redirect? rejects an unsafe destination" do
@@ -71,7 +77,7 @@ class Fastladder::UrlValidatorTest < ActiveSupport::TestCase
       assert Fastladder::UrlValidator.safe?("http://10.0.0.1/")
       assert Fastladder::UrlValidator.safe?("http://192.168.0.1/feed.xml")
       assert Fastladder::UrlValidator.safe?("http://169.254.169.254/")
-      assert Fastladder::UrlValidator.safe?("http://example.com/feed.xml")
+      assert Fastladder::UrlValidator.safe?("http://#{PUBLIC_ADDRESS}/feed.xml")
     end
   end
 
@@ -96,6 +102,12 @@ class Fastladder::UrlValidatorTest < ActiveSupport::TestCase
   end
 
   private
+
+  # Host names are never looked up for real: the suite must not depend on the
+  # resolver it happens to run with.
+  def with_public_dns(&block)
+    Fastladder::UrlValidator.stub :resolve, [IPAddr.new(PUBLIC_ADDRESS)], &block
+  end
 
   def with_intranet_feeds(value)
     previous = ENV[Fastladder::UrlValidator::INTRANET_ENV_KEY]

--- a/test/lib/fastladder_test.rb
+++ b/test/lib/fastladder_test.rb
@@ -30,4 +30,31 @@ class FastladderTest < ActiveSupport::TestCase
 
     assert_equal "Success", Fastladder.simple_fetch("http://example.com")
   end
+
+  test "simple_fetch does not request a private address" do
+    assert_nil Fastladder.simple_fetch("http://127.0.0.1/feed.xml")
+    assert_not_requested :get, "http://127.0.0.1/feed.xml"
+  end
+
+  test "simple_fetch does not follow a redirect to a private address" do
+    stub_request(:get, "http://example.com")
+      .to_return(status: 302, headers: { "Location" => "http://169.254.169.254/latest/meta-data/" })
+
+    assert_nil Fastladder.simple_fetch("http://example.com")
+    assert_not_requested :get, "http://169.254.169.254/latest/meta-data/"
+  end
+
+  test "simple_fetch does not follow a redirect downgrading https to http" do
+    stub_request(:get, "https://example.com")
+      .to_return(status: 302, headers: { "Location" => "http://example.com" })
+
+    assert_nil Fastladder.simple_fetch("https://example.com")
+    assert_not_requested :get, "http://example.com"
+  end
+
+  test "fetch raises for a private address" do
+    assert_raises Fastladder::UrlValidator::UnsafeUrlError do
+      Fastladder.fetch("http://169.254.169.254/latest/meta-data/")
+    end
+  end
 end

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -86,6 +86,32 @@ class FeedTest < ActiveSupport::TestCase
     end
   end
 
+  test "does not follow a favicon redirect to a private address" do
+    feed = FactoryBot.create(:feed)
+    stub_request(:get, "http://example.com/favicon.ico")
+      .to_return(status: 302, headers: { "Location" => "http://169.254.169.254/favicon.ico" })
+
+    feed.stub :favicon_list, [Addressable::URI.parse("http://example.com/favicon.ico")] do
+      feed.fetch_favicon!
+    end
+    assert_not_requested :get, "http://169.254.169.254/favicon.ico"
+    assert_nil feed.favicon.image
+  end
+
+  test "follows a favicon redirect to a public address" do
+    feed = FactoryBot.create(:feed)
+    favicon = File.read(Rails.root.join("test/fixtures/favicon.ico"))
+    stub_request(:get, "http://example.com/favicon.ico")
+      .to_return(status: 302, headers: { "Location" => "http://icon.example.com/favicon.ico" })
+    stub_request(:get, "http://icon.example.com/favicon.ico")
+      .to_return(headers: { "Content-Type" => "image/vnd.microsoft.icon" }, body: favicon)
+
+    feed.stub :favicon_list, [Addressable::URI.parse("http://example.com/favicon.ico")] do
+      feed.fetch_favicon!
+    end
+    assert feed.favicon.image.start_with?("\x89PNG\r\n".force_encoding("ascii-8bit"))
+  end
+
   test "logs errors when favicon.ico is not valid data" do
     feed = FactoryBot.create(:feed)
     stub_request(:any, /.*/).to_return(body: "invalid image data")


### PR DESCRIPTION
Fixes #575.

Feed URLs are user supplied, but nothing checked where they pointed, so `http://127.0.0.1/`, `http://192.168.0.1/` or `http://169.254.169.254/` were fetched happily by both the crawler and the on-request fetches. Verified against a local HTTP server before the change: `simple_fetch("http://127.0.0.1:8123/")` returned the server's content.

## Changes

* New `Fastladder::UrlValidator` (`lib/fastladder/url_validator.rb`): a URL is safe only when its scheme is http/https and none of the addresses its host resolves to falls in a loopback, private, link-local, CGNAT, multicast or reserved range (IPv4, IPv6, and IPv4-mapped IPv6). Because resolution goes through `Addrinfo.getaddrinfo`, alternative notations such as `http://2130706433/` and host names pointing at internal addresses are covered as well.
* `Fastladder.fetch` validates the URL before connecting, so every crawl is checked, including the ones that follow a redirect.
* `Fastladder.simple_fetch` no longer delegates redirect following to `HTTP.follow`. It follows redirects itself (same limit of 5), validating every hop and rejecting https to http downgrades.
* `Fastladder::Crawler` no longer persists a redirect target into `feed.feedlink` unless it passes the same check, which closes the amplifier where a feed publisher could point the crawler at an internal URL for every subscriber.
* `Api::FeedController#discover` and `SubscribeController#confirm` validate the URL before handing it to `FeedSearcher`, which fetches with its own Mechanize instance.
* `Feed#fetch_favicon!` skips favicon URLs that do not pass the check.

## Subscribing to intranet feeds

The address check would otherwise make it impossible to read feeds served inside the network fastladder runs in, which the README lists as one of the things OpenFL is for. The new `ALLOW_INTRANET_FEEDS` environment variable makes that an explicit opt-out:

* Unset, or set to anything other than `1`, `true`, `yes` or `on` (case-insensitive): the address check applies. This is the default, so a plain upgrade stays secure.
* Set to a truthy value: private, loopback, link-local and the other blocked ranges are accepted, for direct fetches and for redirect targets alike.

The scheme check is not affected by the variable, so `file://` and friends are rejected in both modes. The variable is read at call time from `ENV`, so it has to be set for the web process and for the crawler process, each of which fetches feeds on its own. `README.md` documents the variable, its default and when turning it on is reasonable.

## Notes

* A host that does not resolve is left to the HTTP layer, which cannot connect to it either.
* `FeedSearcher` follows redirects with its own Mechanize instance, so a page that redirects to an internal URL can still be requested blindly during discovery. Nothing is returned to the caller, because the feed body is then fetched through `simple_fetch`, which validates. Closing that fully needs a change in the feed_searcher gem.

## Testing

* `bin/rails test`: 274 runs, 577 assertions, 0 failures, 0 errors. New tests cover the validator, the two fetch entry points, the crawler redirect handling, and both states of `ALLOW_INTRANET_FEEDS` (which values count as truthy, intranet addresses accepted when on, schemes still rejected when on, redirects to intranet hosts allowed when on but still no https downgrade).
* `bin/rails test:system` was not run locally (no Chrome/xvfb in this environment); it runs in CI.
* Manually confirmed that fetching a real public feed, including an http to https redirect chain, still works.
