### PR TITLE
Fix IDOR in mobile controller (#578)

### DIFF
--- a/app/controllers/mobile_controller.rb
+++ b/app/controllers/mobile_controller.rb
@@ -11,12 +11,12 @@ class MobileController < ApplicationController # rubocop:todo Style/Documentatio
   end
 
   def read_feed
-    @subscription = Subscription.find(params[:feed_id])
+    @subscription = current_member.subscriptions.find(params[:feed_id])
     @items = @subscription.feed.items.stored_since(@subscription.viewed_on).order('stored_on asc').limit(200)
   end
 
   def mark_as_read
-    @subscription = Subscription.find(params[:feed_id])
+    @subscription = current_member.subscriptions.find(params[:feed_id])
     @subscription.update!(has_unread: false, viewed_on: Time.at(params[:timestamp].to_i + 1))
 
     redirect_to '/mobile'
@@ -24,11 +24,12 @@ class MobileController < ApplicationController # rubocop:todo Style/Documentatio
 
   def pin
     item = Item.find(params[:item_id])
+    subscription = current_member.subscriptions.find_by!(feed_id: item.feed_id)
     begin
       current_member.pins.create!(link: item.link, title: item.title)
     rescue ActiveRecord::RecordNotUnique
     end
 
-    redirect_to "/mobile/#{item.feed_id}#item-#{item.id}"
+    redirect_to "/mobile/#{subscription.id}#item-#{item.id}"
   end
 end

--- a/test/controllers/mobile_controller_test.rb
+++ b/test/controllers/mobile_controller_test.rb
@@ -21,4 +21,55 @@ class MobileControllerTest < ActionController::TestCase
     assert_no_match(/style=/, rendered_body)
     assert_match(/<b>hello<\/b>/, rendered_body)
   end
+
+  test "GET read_feed does not expose another member's subscription" do
+    subscription = other_members_subscription
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      get :read_feed, params: { feed_id: subscription.id }, session: { member_id: @member.id }
+    end
+  end
+
+  test "GET mark_as_read does not touch another member's subscription" do
+    subscription = other_members_subscription
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      get :mark_as_read, params: { feed_id: subscription.id, timestamp: Time.now.to_i },
+                         session: { member_id: @member.id }
+    end
+    assert subscription.reload.has_unread
+  end
+
+  test "GET pin does not pin an item from a feed the member is not subscribed to" do
+    subscription = other_members_subscription
+    item = subscription.feed.items.first
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      get :pin, params: { item_id: item.id }, session: { member_id: @member.id }
+    end
+    assert_equal 0, @member.pins.count
+  end
+
+  test "GET pin redirects back to the member's own subscription" do
+    # Unsubscribed feeds keep the feed id and the subscription id from lining up.
+    FactoryBot.create_list(:feed, 3)
+    item = FactoryBot.create(:item, stored_on: 1.hour.ago)
+    feed = FactoryBot.create(:feed, items: [ item ])
+    subscription = @member.subscriptions.create!(feed: feed, has_unread: true, viewed_on: 2.hours.ago)
+
+    get :pin, params: { item_id: item.id }, session: { member_id: @member.id }
+
+    assert_redirected_to "/mobile/#{subscription.id}#item-#{item.id}"
+    assert_equal [ item.link ], @member.pins.pluck(:link)
+  end
+
+  private
+
+  def other_members_subscription
+    other_member = FactoryBot.create(:member, username: "someone-else", email: "someone-else@example.com",
+                                              password: "mala", password_confirmation: "mala")
+    item = FactoryBot.create(:item, stored_on: 1.hour.ago)
+    feed = FactoryBot.create(:feed, items: [ item ])
+    other_member.subscriptions.create!(feed: feed, has_unread: true, viewed_on: 2.hours.ago)
+  end
 end


### PR DESCRIPTION
Closes #578.

`MobileController#read_feed` and `#mark_as_read` looked subscriptions up with a bare
`Subscription.find(params[:feed_id])`, so any logged-in member could read another
member's feed items, or mark their subscriptions as read, just by guessing subscription
ids. Both lookups are now scoped to `current_member.subscriptions`, which turns a
foreign id into a 404.

`#pin` had the same problem: it pinned any `Item` by id, which leaked the title and
link of items from feeds the member is not subscribed to. It now requires the member to
be subscribed to the item's feed.

While fixing that, the redirect at the end of `#pin` turned out to be wrong: it built
`/mobile/#{item.feed_id}`, but that route takes a *subscription* id, so it sent the
member to an unrelated subscription (or, before this change, to another member's one).
It now redirects to the subscription the item actually came from.

## Tests

Added four controller tests covering the ownership checks and the redirect. All four
fail on master and pass with this change. Full suite: 280 runs, 0 failures.