### PR TITLE
Enforce CSRF protection on session authenticated requests

### DIFF
--- a/app/assets/javascripts/lib/reader/main.js
+++ b/app/assets/javascripts/lib/reader/main.js
@@ -3,21 +3,8 @@ window.onresize = function(){LDR.invoke_hook('WINDOW_RESIZE')};
 
 var app = LDR.Application.getInstance();
 
-// API Key
-(function(){
-	LDR.API.StickyQuery = { ApiKey: ApiKey };
-	function getApiKey(){
-	    var ck = new Cookie().parse();
-	    for(var key in ck){
-	        if(/_sid/.test(key)){
-	            return ck[key]
-	        }
-	    }
-	};
-	if(/^\[/.test(ApiKey)){
-	    LDR.API.StickyQuery = { ApiKey: getApiKey() };
-	}
-}).call(LDR);
+// CSRF token, sent along with every API request
+LDR.API.StickyQuery = { ApiKey: ApiKey };
 
 
 /*

--- a/app/controllers/api/config_controller.rb
+++ b/app/controllers/api/config_controller.rb
@@ -1,7 +1,6 @@
 require "yaml"
 class Api::ConfigController < ApplicationController
   before_action :login_required_api
-  skip_before_action :verify_authenticity_token
 
   APP_CONFIG = Settings.to_h.slice(:save_pin_limit)
 

--- a/app/controllers/api/feed_controller.rb
+++ b/app/controllers/api/feed_controller.rb
@@ -6,7 +6,6 @@ class Api::FeedController < ApplicationController
   params_required [ :subscribe_id, :rate   ], only: :set_rate
   params_required [ :subscribe_id, :ignore ], only: :set_notify
   params_required [ :subscribe_id, :public ], only: :set_public
-  skip_before_action :verify_authenticity_token
 
   def discover
     feeds = []
@@ -92,7 +91,7 @@ class Api::FeedController < ApplicationController
       return render_json_status(false)
     end
     result = {
-      ApiKey: session[:session_id],
+      ApiKey: form_authenticity_token,
       subscribe_id: sub.id,
       folder_id: sub.folder_id || 0,
       rate: sub.rate,

--- a/app/controllers/api/folder_controller.rb
+++ b/app/controllers/api/folder_controller.rb
@@ -2,7 +2,6 @@ class Api::FolderController < ApplicationController
   before_action :login_required_api
   # we need not check folder_id, because it checked by each method
   params_required :name, only: [ :create, :update ]
-  skip_before_action :verify_authenticity_token
 
   ERR_ALREADY_EXISTS = 10
 

--- a/app/controllers/api/pin_controller.rb
+++ b/app/controllers/api/pin_controller.rb
@@ -2,7 +2,6 @@ class Api::PinController < ApplicationController
   before_action :login_required_api
   params_required [:link, :title], only: :add
   params_required :link, only: :remove
-  skip_before_action :verify_authenticity_token
 
   module ErrorCode
     NOT_FOUND = 2

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -4,7 +4,6 @@ class ApiController < ApplicationController
   params_required [:timestamp, :subscribe_id], only: :touch
   params_required :since, only: [:item_count, :unread_count]
   before_action :find_sub, only: [:all, :unread]
-  skip_before_action :verify_authenticity_token
 
   def all
     if params[:limit].blank?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -57,6 +57,17 @@ class ApplicationController < ActionController::Base
 
   private
 
+  # The JavaScript front end sends the CSRF token as the "ApiKey" parameter.
+  def request_authenticity_tokens
+    super + [params[:ApiKey]]
+  end
+
+  # Requests authenticated with an API key instead of the session cookie are
+  # not reachable by cross site request forgery.
+  def verified_request?
+    super || find_current_member_by_auth_key.present?
+  end
+
   def current_member
     @member ||= find_current_member_by_session || find_current_member_by_auth_key
   end

--- a/app/controllers/subscribe_controller.rb
+++ b/app/controllers/subscribe_controller.rb
@@ -1,6 +1,5 @@
 class SubscribeController < ApplicationController
   before_action :login_required
-  skip_before_action :verify_authenticity_token, only: [:subscribe]
 
   def index
     if params[:url].present?

--- a/app/views/contents/edit.html.erb
+++ b/app/views/contents/edit.html.erb
@@ -1,6 +1,6 @@
 <%= form_for :feed, url: url_for(controller: "api/feed", action: "update"), html: {id: "subs_edit_form"} do |f| %>
 <%= f.hidden_field :subscribe_id, name: "subscribe_id" %>
-<%= f.hidden_field :api_key, name: "ApiKey", value: session[:session_id] %>
+<%= f.hidden_field :api_key, name: "ApiKey", value: form_authenticity_token %>
 <table>
 <tr>
 	<th>Folder</th>

--- a/app/views/import/fetch.html.erb
+++ b/app/views/import/fetch.html.erb
@@ -37,7 +37,7 @@ function s_toggle(mode,tab){
 
 <% if @opml.present? -%>
 <%= form_for :import, url: import_finish_path do |f| %>
-<%= f.hidden_field :api_key, name: "ApiKey", value: session[:session_id] %>
+<%= f.hidden_field :api_key, name: "ApiKey", value: form_authenticity_token %>
 <div id="registerbox" style="width:auto;margin:0 10px">
 	<div id="import_tab" class="tabs" style="text-align:left;padding-left:15px;">
 		<div class="tab tab-active" onclick="s_toggle('all',this)">All<span class="num">(<%= all_count = (all_items = @folders.values.flatten).length %>)</span></div>

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,7 +12,7 @@
     - if content_for? :extract_header
       = yield :extract_header
   %body{class: params[:controller]}
-    %span#ApiKey(style="display:none" data-api-key="#{session[:session_id]}")
+    %span#ApiKey(style="display:none" data-api-key="#{form_authenticity_token}")
     #container
       .navi
         %h1.logo= link_to "Fastladder", root_path
@@ -34,7 +34,7 @@
             = flash[:alert]
       = yield
     :javascript
-      var ApiKey = '#{escape_javascript(session[:session_id])}';
+      var ApiKey = '#{escape_javascript(form_authenticity_token)}';
     = javascript_include_tag "application"
     = javascript_include_tag "vendor/flow.min" 
     = javascript_include_tag "vendor/zepto.min" 

--- a/app/views/reader/index.html.erb
+++ b/app/views/reader/index.html.erb
@@ -473,7 +473,7 @@
 <!-- /TEMPLATE -->
 
 <script type="text/javascript">
-var ApiKey = "<%= session[:session_id]  %>";
+var ApiKey = "<%= form_authenticity_token  %>";
 
 function ads_mouseover(){
 	if(typeof Element == 'object'){

--- a/app/views/share/index.html.erb
+++ b/app/views/share/index.html.erb
@@ -73,7 +73,7 @@
 </div>
 </div>
 
-<script type="text/javascript">var ApiKey = "<%= session[:session_id] %>";</script>
+<script type="text/javascript">var ApiKey = "<%= form_authenticity_token %>";</script>
 
 <%= javascript_include_tag "vendor/flow.min" %>
 <%= javascript_include_tag "vendor/zepto.min" %>

--- a/app/views/subscribe/confirm.html.erb
+++ b/app/views/subscribe/confirm.html.erb
@@ -9,7 +9,7 @@
 	<h3>You can subscribe to</h3>
 	<input type="hidden" name="url" value="<%= @url %>" id="target_url">
 	<input type="hidden" name="register" value="1">
-	<input type="hidden" name="ApiKey" value="<%= session[:session_id] %>">
+	<input type="hidden" name="ApiKey" value="<%= form_authenticity_token %>">
 	<ul id="feed_candidates">
 		<% @feeds.uniq {|feed| feed.feedlink }.each_with_index do |feed, i| -%>
 		<li class="list<% if i == 0 %> list-first<% end %>">
@@ -104,6 +104,6 @@
 </div><!-- /content-inner -->
 </div><!-- /content -->
 
-<script type="text/javascript">var ApiKey = "<%= session[:session_id] %>";</script>
+<script type="text/javascript">var ApiKey = "<%= form_authenticity_token %>";</script>
 <%= javascript_include_tag "subscribe" %>
 <script type="text/javascript">if(typeof init == "function") init();</script>

--- a/app/views/subscribe/index.html.erb
+++ b/app/views/subscribe/index.html.erb
@@ -19,5 +19,5 @@
 </div>
 </div>
 </div>
-<script type="text/javascript">var ApiKey = "<%= session[:session_id] %>";</script>
+<script type="text/javascript">var ApiKey = "<%= form_authenticity_token %>";</script>
 <%= javascript_include_tag "subscribe" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,8 +36,12 @@ Rails.application.routes.draw do
       post  :save, action: :setter
     end
 
-    %w(all unread touch_all touch item_count unread_count crawl).each do |name|
+    %w(all unread item_count unread_count).each do |name|
       match name, via: [:get, :post]
+    end
+
+    %w(touch_all touch crawl).each do |name|
+      post name
     end
 
     %w[subs lite_subs error_subs folders].each do |name|

--- a/test/requests/csrf_protection_test.rb
+++ b/test/requests/csrf_protection_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+
+class CsrfProtectionTest < ActionDispatch::IntegrationTest
+  def setup
+    @member = FactoryBot.create(:member, password: "mala", password_confirmation: "mala")
+    @member.set_auth_key
+    @feed = FactoryBot.create(:feed)
+    @subscription = FactoryBot.create(:subscription, feed: @feed, member: @member, has_unread: true)
+    post session_path, params: { username: @member.username, password: "mala" }
+  end
+
+  def teardown
+    ActionController::Base.allow_forgery_protection = false
+  end
+
+  test "session authenticated api call is rejected without a token" do
+    with_forgery_protection do
+      post "/api/touch_all", params: { subscribe_id: @subscription.id }
+    end
+
+    assert_response :unprocessable_entity
+    assert @subscription.reload.has_unread
+  end
+
+  test "session authenticated api call is accepted with the ApiKey token" do
+    with_forgery_protection do
+      post "/api/touch_all", params: { subscribe_id: @subscription.id, ApiKey: api_key }
+    end
+
+    assert_response :success
+    assert_not @subscription.reload.has_unread
+  end
+
+  test "api key authenticated api call is accepted without a token" do
+    reset!
+
+    with_forgery_protection do
+      post "/api/touch_all", params: { subscribe_id: @subscription.id, auth_key: @member.auth_key }
+    end
+
+    assert_response :success
+    assert_not @subscription.reload.has_unread
+  end
+
+  test "subscribe is rejected without a token" do
+    with_forgery_protection do
+      post "/subscribe/http://example.com/", params: { check_for_subscribe: ["http://example.com/feed"] }
+    end
+
+    assert_response :unprocessable_entity
+    assert_equal 1, @member.subscriptions.count
+  end
+
+  private
+
+  def with_forgery_protection
+    ActionController::Base.allow_forgery_protection = true
+    yield
+  ensure
+    ActionController::Base.allow_forgery_protection = false
+  end
+
+  # Read the token the front end sends back as the ApiKey parameter.
+  def api_key
+    get reader_path
+    assert_response :success
+    response.body[/var ApiKey = "([^"]+)"/, 1]
+  end
+end

--- a/test/routing/api_routing_test.rb
+++ b/test/routing/api_routing_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class ApiRoutingTest < ActionDispatch::IntegrationTest
-  %w(all unread touch_all touch item_count unread_count crawl).each do |name|
+  %w(all unread item_count unread_count).each do |name|
     test "routes #{name} via GET" do
       assert_routing(
         { method: "get", path: "/api/#{name}" },
@@ -17,7 +17,7 @@ class ApiRoutingTest < ActionDispatch::IntegrationTest
     end
   end
 
-  %w(subs lite_subs error_subs folders).each do |name|
+  %w(touch_all touch crawl subs lite_subs error_subs folders).each do |name|
     test "routes #{name}" do
       assert_routing(
         { method: "post", path: "/api/#{name}" },


### PR DESCRIPTION
Fixes #576.

The API controllers skipped `verify_authenticity_token` while still accepting session cookie authentication, and `/api/touch_all`, `/api/touch` and `/api/crawl` were routed via GET as well as POST. An attacker page could therefore mark a logged in victim's feeds as read, trigger crawls, or force a subscription through `POST /subscribe/*url`.

## Changes

- `touch_all`, `touch` and `crawl` are now POST only, so they are no longer reachable from an `<img>` tag or a plain link.
- `skip_before_action :verify_authenticity_token` is removed from `ApiController`, `Api::*` and `SubscribeController`.
- The front end already sends an `ApiKey` parameter with every API request. It now carries a real CSRF token instead of the (unused) session id, and `ApplicationController#request_authenticity_tokens` accepts it alongside the standard parameter and header.
- `verified_request?` still returns true for requests authenticated with an `auth_key` API key, since those do not rely on the session cookie and are not reachable by forgery.
- `RpcController` keeps skipping verification: it authenticates solely through its own `api_key` parameter and never uses the session.

## Tests

`test/requests/csrf_protection_test.rb` runs with forgery protection enabled and covers: a session authenticated state change rejected without a token, accepted with the `ApiKey` token, accepted when authenticated by an API key, and `POST /subscribe/*url` rejected without a token. The API routing test now asserts the POST-only verbs.

`./bin/rails test` passes (284 runs, 0 failures). System tests were not run locally because no browser is available in this environment.